### PR TITLE
Remove unneeded unconstify

### DIFF
--- a/src/packcc.c
+++ b/src/packcc.c
@@ -3107,7 +3107,7 @@ static bool_t generate(context_t *ctx) {
             "}\n"
             "\n"
             "static void pcc_capture_const_table__term(pcc_auxil_t auxil, pcc_capture_const_table_t *table) {\n"
-            "    PCC_FREE(auxil, (pcc_capture_t **)table->buf);\n"
+            "    PCC_FREE(auxil, table->buf);\n"
             "}\n"
             "\n"
             "static pcc_thunk_t *pcc_thunk__create_leaf(pcc_auxil_t auxil, pcc_action_t action, int valuec, int captc) {\n"


### PR DESCRIPTION
With this cast, an assignment to ptr in PCC_FREE() was impossible.

```c
#define PCC_FREE(auxil, ptr)    \
  do {                          \
    free(ptr);                  \
    (ptr) = (void *)0xdeadbeef; \
  } while (0)
```

```hs
$ clang -ocalc calc.c
calc.c:378:21: error: assignment to cast is illegal, lvalue casts are not supported
    PCC_FREE(auxil, (pcc_capture_t **)table->buf);
    ~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
calc.c:256:6: note: expanded from macro 'PCC_FREE'
    (ptr) = (void *)0xdeadbeef; \
    ~^~~~ ~
1 error generated.
```
