### PR TITLE
Nicer debug

### DIFF
--- a/src/packcc.c
+++ b/src/packcc.c
@@ -1444,6 +1444,14 @@ void dump_escaped(const char* s) {
     }
 }
 
+void dump_void_value(ullong_t value) {
+    if (value == VOID_VALUE) {
+        fprintf(stdout, "void");
+    } else {
+        fprintf(stdout, "%llu", value);
+    }
+}
+
 static void dump_node(context_t *ctx, const node_t *node, const int indent) {
     if (node == NULL) return;
     switch (node->type) {
@@ -1455,8 +1463,9 @@ static void dump_node(context_t *ctx, const node_t *node, const int indent) {
         fprintf(stdout, "%*s}\n", indent, "");
         break;
     case NODE_REFERENCE:
-        fprintf(stdout, "%*sReference(var:'%s',index:%llu,name:'%s',rule:'%s')\n",
-            indent, "", node->data.reference.var, (ullong_t)node->data.reference.index, node->data.reference.name,
+        fprintf(stdout, "%*sReference(var:'%s',index:", indent, "", node->data.reference.var);
+        dump_void_value((ullong_t)node->data.reference.index);
+        fprintf(stdout, ",name:'%s',rule:'%s')\n", node->data.reference.name,
             (node->data.reference.rule) ? node->data.reference.rule->data.rule.name : NULL);
         break;
     case NODE_STRING:
@@ -1502,15 +1511,21 @@ static void dump_node(context_t *ctx, const node_t *node, const int indent) {
         fprintf(stdout, "%*s}\n", indent, "");
         break;
     case NODE_CAPTURE:
-        fprintf(stdout, "%*sCapture(index:%llu){\n", indent, "", (ullong_t)node->data.capture.index);
+        fprintf(stdout, "%*sCapture(index:", indent, "");
+        dump_void_value((ullong_t)node->data.capture.index);
+        fprintf(stdout, "){\n");
         dump_node(ctx, node->data.capture.expr, indent + 2);
         fprintf(stdout, "%*s}\n", indent, "");
         break;
     case NODE_EXPAND:
-        fprintf(stdout, "%*sExpand(index:%llu)\n", indent, "", (ullong_t)node->data.expand.index);
+        fprintf(stdout, "%*sExpand(index:", indent, "");
+        dump_void_value((ullong_t)node->data.expand.index);
+        fprintf(stdout, ")\n");
         break;
     case NODE_ACTION:
-        fprintf(stdout, "%*sAction(index:%llu,value:{", indent, "", (ullong_t)node->data.action.index);
+        fprintf(stdout, "%*sAction(index:", indent, "");
+        dump_void_value((ullong_t)node->data.action.index);
+        fprintf(stdout, ",value:{");
         dump_escaped(node->data.action.value);
         fprintf(stdout, "},vars:\n");
         {
@@ -1525,7 +1540,9 @@ static void dump_node(context_t *ctx, const node_t *node, const int indent) {
         fprintf(stdout, "%*s)\n", indent, "");
         break;
     case NODE_ERROR:
-        fprintf(stdout, "%*sError(index:%llu,value:{", indent, "", (ullong_t)node->data.error.index);
+        fprintf(stdout, "%*sError(index:", indent, "");
+        dump_void_value((ullong_t)node->data.error.index);
+        fprintf(stdout, ",value:{");
         dump_escaped(node->data.error.value);
         fprintf(stdout, "},vars:\n");
         {

--- a/src/packcc.c
+++ b/src/packcc.c
@@ -1432,7 +1432,7 @@ static void verify_captures(context_t *ctx, node_t *node, node_const_array_t *ca
     }
 }
 
-void dump_escaped(const char* s) {
+static void dump_escaped(const char* s) {
     char buf[5];
     if (s == NULL) {
         fprintf(stdout, "null");
@@ -1444,7 +1444,7 @@ void dump_escaped(const char* s) {
     }
 }
 
-void dump_void_value(ullong_t value) {
+static void dump_void_value(ullong_t value) {
     if (value == VOID_VALUE) {
         fprintf(stdout, "void");
     } else {

--- a/src/packcc.c
+++ b/src/packcc.c
@@ -1456,16 +1456,16 @@ static void dump_node(context_t *ctx, const node_t *node, const int indent) {
     if (node == NULL) return;
     switch (node->type) {
     case NODE_RULE:
-        fprintf(stdout, "%*sRule(name:'%s',ref:%d,vars.len:%llu,capts.len:%llu,codes.len:%llu){\n",
+        fprintf(stdout, "%*sRule(name:'%s', ref:%d, vars.len:%llu, capts.len:%llu, codes.len:%llu) {\n",
             indent, "", node->data.rule.name, node->data.rule.ref,
             (ullong_t)node->data.rule.vars.len, (ullong_t)node->data.rule.capts.len, (ullong_t)node->data.rule.codes.len);
         dump_node(ctx, node->data.rule.expr, indent + 2);
         fprintf(stdout, "%*s}\n", indent, "");
         break;
     case NODE_REFERENCE:
-        fprintf(stdout, "%*sReference(var:'%s',index:", indent, "", node->data.reference.var);
+        fprintf(stdout, "%*sReference(var:'%s', index:", indent, "", node->data.reference.var);
         dump_void_value((ullong_t)node->data.reference.index);
-        fprintf(stdout, ",name:'%s',rule:'%s')\n", node->data.reference.name,
+        fprintf(stdout, ", name:'%s', rule:'%s')\n", node->data.reference.name,
             (node->data.reference.rule) ? node->data.reference.rule->data.rule.name : NULL);
         break;
     case NODE_STRING:
@@ -1479,17 +1479,17 @@ static void dump_node(context_t *ctx, const node_t *node, const int indent) {
         fprintf(stdout, "')\n");
         break;
     case NODE_QUANTITY:
-        fprintf(stdout, "%*sQuantity(min:%d,max%d){\n", indent, "", node->data.quantity.min, node->data.quantity.max);
+        fprintf(stdout, "%*sQuantity(min:%d, max%d) {\n", indent, "", node->data.quantity.min, node->data.quantity.max);
         dump_node(ctx, node->data.quantity.expr, indent + 2);
         fprintf(stdout, "%*s}\n", indent, "");
         break;
     case NODE_PREDICATE:
-        fprintf(stdout, "%*sPredicate(neg:%d){\n", indent, "", node->data.predicate.neg);
+        fprintf(stdout, "%*sPredicate(neg:%d) {\n", indent, "", node->data.predicate.neg);
         dump_node(ctx, node->data.predicate.expr, indent + 2);
         fprintf(stdout, "%*s}\n", indent, "");
         break;
     case NODE_SEQUENCE:
-        fprintf(stdout, "%*sSequence(max:%llu,len:%llu){\n",
+        fprintf(stdout, "%*sSequence(max:%llu, len:%llu) {\n",
             indent, "", (ullong_t)node->data.sequence.nodes.max, (ullong_t)node->data.sequence.nodes.len);
         {
             size_t i;
@@ -1500,7 +1500,7 @@ static void dump_node(context_t *ctx, const node_t *node, const int indent) {
         fprintf(stdout, "%*s}\n", indent, "");
         break;
     case NODE_ALTERNATE:
-        fprintf(stdout, "%*sAlternate(max:%llu,len:%llu){\n",
+        fprintf(stdout, "%*sAlternate(max:%llu, len:%llu) {\n",
             indent, "", (ullong_t)node->data.alternate.nodes.max, (ullong_t)node->data.alternate.nodes.len);
         {
             size_t i;
@@ -1513,7 +1513,7 @@ static void dump_node(context_t *ctx, const node_t *node, const int indent) {
     case NODE_CAPTURE:
         fprintf(stdout, "%*sCapture(index:", indent, "");
         dump_void_value((ullong_t)node->data.capture.index);
-        fprintf(stdout, "){\n");
+        fprintf(stdout, ") {\n");
         dump_node(ctx, node->data.capture.expr, indent + 2);
         fprintf(stdout, "%*s}\n", indent, "");
         break;
@@ -1525,26 +1525,29 @@ static void dump_node(context_t *ctx, const node_t *node, const int indent) {
     case NODE_ACTION:
         fprintf(stdout, "%*sAction(index:", indent, "");
         dump_void_value((ullong_t)node->data.action.index);
-        fprintf(stdout, ",value:{");
+        fprintf(stdout, ", value:{");
         dump_escaped(node->data.action.value);
-        fprintf(stdout, "},vars:\n");
-        {
+        fprintf(stdout, "}, vars:");
+        if (node->data.action.vars.len + node->data.action.capts.len > 0) {
             size_t i;
+            fprintf(stdout, "\n");
             for (i = 0; i < node->data.action.vars.len; i++) {
                 fprintf(stdout, "%*s'%s'\n", indent + 2, "", node->data.action.vars.buf[i]->data.reference.var);
             }
             for (i = 0; i < node->data.action.capts.len; i++) {
                 fprintf(stdout, "%*s$%llu\n", indent + 2, "", (ullong_t)(node->data.action.capts.buf[i]->data.capture.index + 1));
             }
+            fprintf(stdout, "%*s)\n", indent, "");
+        } else {
+            fprintf(stdout, "none)\n");
         }
-        fprintf(stdout, "%*s)\n", indent, "");
         break;
     case NODE_ERROR:
         fprintf(stdout, "%*sError(index:", indent, "");
         dump_void_value((ullong_t)node->data.error.index);
-        fprintf(stdout, ",value:{");
+        fprintf(stdout, ", value:{");
         dump_escaped(node->data.error.value);
-        fprintf(stdout, "},vars:\n");
+        fprintf(stdout, "}, vars:\n");
         {
             size_t i;
             for (i = 0; i < node->data.error.vars.len; i++) {
@@ -1554,7 +1557,7 @@ static void dump_node(context_t *ctx, const node_t *node, const int indent) {
                 fprintf(stdout, "%*s$%llu\n", indent + 2, "", (ullong_t)(node->data.error.capts.buf[i]->data.capture.index + 1));
             }
         }
-        fprintf(stdout, "%*s){\n", indent, "");
+        fprintf(stdout, "%*s) {\n", indent, "");
         dump_node(ctx, node->data.error.expr, indent + 2);
         fprintf(stdout, "%*s}\n", indent, "");
         break;
@@ -2187,9 +2190,9 @@ static const char *get_prefix(context_t *ctx) {
 }
 
 static void dump_options(context_t *ctx) {
-    fprintf(stdout, "value_type:'%s'\n", get_value_type(ctx));
-    fprintf(stdout, "auxil_type:'%s'\n", get_auxil_type(ctx));
-    fprintf(stdout, "prefix:'%s'\n", get_prefix(ctx));
+    fprintf(stdout, "value_type: '%s'\n", get_value_type(ctx));
+    fprintf(stdout, "auxil_type: '%s'\n", get_auxil_type(ctx));
+    fprintf(stdout, "prefix: '%s'\n", get_prefix(ctx));
 }
 
 static bool_t parse_directive_include_(context_t *ctx, const char *name, FILE *output1, FILE *output2) {

--- a/src/packcc.c
+++ b/src/packcc.c
@@ -1432,95 +1432,117 @@ static void verify_captures(context_t *ctx, node_t *node, node_const_array_t *ca
     }
 }
 
-static void dump_node(context_t *ctx, const node_t *node) {
+void dump_escaped(const char* s) {
+    char buf[5];
+    if (s == NULL) {
+        fprintf(stdout, "null");
+        return;
+    }
+    while(*s) {
+        escape_character(*s++, &buf);
+        fprintf(stdout, "%s", buf);
+    }
+}
+
+static void dump_node(context_t *ctx, const node_t *node, const int indent) {
     if (node == NULL) return;
     switch (node->type) {
     case NODE_RULE:
-        fprintf(stdout, "Rule(name:'%s',ref:%d,vars.len:%llu,capts.len:%llu,codes.len:%llu){\n",
-            node->data.rule.name, node->data.rule.ref,
+        fprintf(stdout, "%*sRule(name:'%s',ref:%d,vars.len:%llu,capts.len:%llu,codes.len:%llu){\n",
+            indent, "", node->data.rule.name, node->data.rule.ref,
             (ullong_t)node->data.rule.vars.len, (ullong_t)node->data.rule.capts.len, (ullong_t)node->data.rule.codes.len);
-        dump_node(ctx, node->data.rule.expr);
-        fprintf(stdout, "}\n");
+        dump_node(ctx, node->data.rule.expr, indent + 2);
+        fprintf(stdout, "%*s}\n", indent, "");
         break;
     case NODE_REFERENCE:
-        fprintf(stdout, "Reference(var:'%s',index:%llu,name:'%s',rule:'%s')\n",
-            node->data.reference.var, (ullong_t)node->data.reference.index, node->data.reference.name,
+        fprintf(stdout, "%*sReference(var:'%s',index:%llu,name:'%s',rule:'%s')\n",
+            indent, "", node->data.reference.var, (ullong_t)node->data.reference.index, node->data.reference.name,
             (node->data.reference.rule) ? node->data.reference.rule->data.rule.name : NULL);
         break;
     case NODE_STRING:
-        fprintf(stdout, "String(value:'%s')\n", node->data.string.value);
+        fprintf(stdout, "%*sString(value:'", indent, "");
+        dump_escaped(node->data.string.value);
+        fprintf(stdout, "')\n");
         break;
     case NODE_CHARCLASS:
-        fprintf(stdout, "Charclass(value:'%s')\n", node->data.charclass.value);
+        fprintf(stdout, "%*sCharclass(value:'", indent, "");
+        dump_escaped(node->data.charclass.value);
+        fprintf(stdout, "')\n");
         break;
     case NODE_QUANTITY:
-        fprintf(stdout, "Quantity(min:%d,max%d){\n", node->data.quantity.min, node->data.quantity.max);
-        dump_node(ctx, node->data.quantity.expr);
-        fprintf(stdout, "}\n");
+        fprintf(stdout, "%*sQuantity(min:%d,max%d){\n", indent, "", node->data.quantity.min, node->data.quantity.max);
+        dump_node(ctx, node->data.quantity.expr, indent + 2);
+        fprintf(stdout, "%*s}\n", indent, "");
         break;
     case NODE_PREDICATE:
-        fprintf(stdout, "Predicate(neg:%d){\n", node->data.predicate.neg);
-        dump_node(ctx, node->data.predicate.expr);
-        fprintf(stdout, "}\n");
+        fprintf(stdout, "%*sPredicate(neg:%d){\n", indent, "", node->data.predicate.neg);
+        dump_node(ctx, node->data.predicate.expr, indent + 2);
+        fprintf(stdout, "%*s}\n", indent, "");
         break;
     case NODE_SEQUENCE:
-        fprintf(stdout, "Sequence(max:%llu,len:%llu){\n", (ullong_t)node->data.sequence.nodes.max, (ullong_t)node->data.sequence.nodes.len);
+        fprintf(stdout, "%*sSequence(max:%llu,len:%llu){\n",
+            indent, "", (ullong_t)node->data.sequence.nodes.max, (ullong_t)node->data.sequence.nodes.len);
         {
             size_t i;
             for (i = 0; i < node->data.sequence.nodes.len; i++) {
-                dump_node(ctx, node->data.sequence.nodes.buf[i]);
+                dump_node(ctx, node->data.sequence.nodes.buf[i], indent + 2);
             }
         }
-        fprintf(stdout, "}\n");
+        fprintf(stdout, "%*s}\n", indent, "");
         break;
     case NODE_ALTERNATE:
-        fprintf(stdout, "Alternate(max:%llu,len:%llu){\n", (ullong_t)node->data.alternate.nodes.max, (ullong_t)node->data.alternate.nodes.len);
+        fprintf(stdout, "%*sAlternate(max:%llu,len:%llu){\n",
+            indent, "", (ullong_t)node->data.alternate.nodes.max, (ullong_t)node->data.alternate.nodes.len);
         {
             size_t i;
             for (i = 0; i < node->data.alternate.nodes.len; i++) {
-                dump_node(ctx, node->data.alternate.nodes.buf[i]);
+                dump_node(ctx, node->data.alternate.nodes.buf[i], indent + 2);
             }
         }
-        fprintf(stdout, "}\n");
+        fprintf(stdout, "%*s}\n", indent, "");
         break;
     case NODE_CAPTURE:
-        fprintf(stdout, "Capture(index:%llu){\n", (ullong_t)node->data.capture.index);
-        dump_node(ctx, node->data.capture.expr);
-        fprintf(stdout, "}\n");
+        fprintf(stdout, "%*sCapture(index:%llu){\n", indent, "", (ullong_t)node->data.capture.index);
+        dump_node(ctx, node->data.capture.expr, indent + 2);
+        fprintf(stdout, "%*s}\n", indent, "");
         break;
     case NODE_EXPAND:
-        fprintf(stdout, "Expand(index:%llu)\n", (ullong_t)node->data.expand.index);
+        fprintf(stdout, "%*sExpand(index:%llu)\n", indent, "", (ullong_t)node->data.expand.index);
         break;
     case NODE_ACTION:
-        fprintf(stdout, "Action(index:%llu,value:{%s},vars:\n", (ullong_t)node->data.action.index, node->data.action.value);
+        fprintf(stdout, "%*sAction(index:%llu,value:{", indent, "", (ullong_t)node->data.action.index);
+        dump_escaped(node->data.action.value);
+        fprintf(stdout, "},vars:\n");
         {
             size_t i;
             for (i = 0; i < node->data.action.vars.len; i++) {
-                fprintf(stdout, "    '%s'\n", node->data.action.vars.buf[i]->data.reference.var);
+                fprintf(stdout, "%*s'%s'\n", indent + 2, "", node->data.action.vars.buf[i]->data.reference.var);
             }
             for (i = 0; i < node->data.action.capts.len; i++) {
-                fprintf(stdout, "    $%llu\n", (ullong_t)(node->data.action.capts.buf[i]->data.capture.index + 1));
+                fprintf(stdout, "%*s$%llu\n", indent + 2, "", (ullong_t)(node->data.action.capts.buf[i]->data.capture.index + 1));
             }
         }
-        fprintf(stdout, ")\n");
+        fprintf(stdout, "%*s)\n", indent, "");
         break;
     case NODE_ERROR:
-        fprintf(stdout, "Error(index:%llu,value:{%s},vars:\n", (ullong_t)node->data.error.index, node->data.error.value);
+        fprintf(stdout, "%*sError(index:%llu,value:{", indent, "", (ullong_t)node->data.error.index);
+        dump_escaped(node->data.error.value);
+        fprintf(stdout, "},vars:\n");
         {
             size_t i;
             for (i = 0; i < node->data.error.vars.len; i++) {
-                fprintf(stdout, "    '%s'\n", node->data.error.vars.buf[i]->data.reference.var);
+                fprintf(stdout, "%*s'%s'\n", indent + 2, "", node->data.error.vars.buf[i]->data.reference.var);
             }
             for (i = 0; i < node->data.error.capts.len; i++) {
-                fprintf(stdout, "    $%llu\n", (ullong_t)(node->data.error.capts.buf[i]->data.capture.index + 1));
+                fprintf(stdout, "%*s$%llu\n", indent + 2, "", (ullong_t)(node->data.error.capts.buf[i]->data.capture.index + 1));
             }
         }
-        fprintf(stdout, "){\n");
-        dump_node(ctx, node->data.error.expr);
-        fprintf(stdout, "}\n");
+        fprintf(stdout, "%*s){\n", indent, "");
+        dump_node(ctx, node->data.error.expr, indent + 2);
+        fprintf(stdout, "%*s}\n", indent, "");
         break;
     default:
-        print_error("Internal error [%d]\n", __LINE__);
+        print_error("%*sInternal error [%d]\n", indent, "", __LINE__);
         exit(-1);
     }
 }
@@ -2364,7 +2386,7 @@ static bool_t parse(context_t *ctx) {
     if (ctx->debug) {
         size_t i;
         for (i = 0; i < ctx->rules.len; i++) {
-            dump_node(ctx, ctx->rules.buf[i]);
+            dump_node(ctx, ctx->rules.buf[i], 0);
         }
         dump_options(ctx);
     }


### PR DESCRIPTION
I found the `--debug` option quite useful, but a little hard to read. This PR contains simple proposal to make it more readable. Here is an example output  for tests/basic.d/input.peg:

When run in current master:
```
Rule(name:'FILE',ref:0,vars.len:0,capts.len:0,codes.len:0){
Alternate(max:2,len:2){
Reference(var:'(null)',index:18446744073709551615,name:'WORD',rule:'WORD')
Reference(var:'(null)',index:18446744073709551615,name:'SPACE',rule:'SPACE')
}
}
Rule(name:'WORD',ref:1,vars.len:0,capts.len:0,codes.len:1){
Sequence(max:2,len:2){
Quantity(min:1,max-1){
Charclass(value:'^ 
	')
}
Action(index:0,value:{ PRINT(_0); },vars:
)
}
}
Rule(name:'SPACE',ref:1,vars.len:0,capts.len:0,codes.len:0){
Quantity(min:1,max-1){
Charclass(value:' 
	')
}
}
value_type:'int'
auxil_type:'void *'
prefix:'pcc'
```

With this patch:
```
Rule(name:'FILE', ref:0, vars.len:0, capts.len:0, codes.len:0) {
  Alternate(max:2, len:2) {
    Reference(var:'(null)', index:void, name:'WORD', rule:'WORD')
    Reference(var:'(null)', index:void, name:'SPACE', rule:'SPACE')
  }
}
Rule(name:'WORD', ref:1, vars.len:0, capts.len:0, codes.len:1) {
  Sequence(max:2, len:2) {
    Quantity(min:1, max-1) {
      Charclass(value:'^ \r\n\t')
    }
    Action(index:0, value:{ PRINT(_0); }, vars:none)
  }
}
Rule(name:'SPACE', ref:1, vars.len:0, capts.len:0, codes.len:0) {
  Quantity(min:1, max-1) {
    Charclass(value:' \r\n\t')
  }
}
value_type: 'int'
auxil_type: 'void *'
prefix: 'pcc'
```