### PR TITLE
Add macro to debug generated parsers

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,6 +378,35 @@ The default is defined as below.
 #define PCC_FREE(auxil, ptr) free(ptr)
 ```
 
+**`PCC_DEBUG(`**_event_**`,`**_rule_**`,`**_level_**`,`**_pos_**`,`**_buffer_**`,`**_length_**`)`**
+
+The function macro for debugging. Sometimes, especially for complex parsers, it is useful to see how exactly the parser processes the input. This macro is called on important *events* and allows to log or display current state of the parsers. The argument `rule` is a string that contains name of currently evaluated rule. Non-negative integer `level` is a specifying how deep in the rule hierarchy the parser currently is. Argument `pos` holds position from the start of current context in bytes. In case of `event == DBG_MATCH` argument `buffer` holds matched input and `length` is its size. for other events `buffer` and `length` describe part of currently loaded input, that is used to evaluate rule.
+
+There are currently three supported events:
+ - `DBG_EVALUATE` - called when the parser starts to evaluate `rule`
+ - `DBG_MATCH` - called when `rule` is matched, at which point buffer holds entire matched string
+ - `DBG_NOMATCH` - called when the parsers determines that the input does not match currently evaluated `rule`
+
+Very simple implementation could look like this:
+
+```C
+static const char *dbg_str(int event) {
+    switch(event) {
+        case PCC_DBG_EVALUATE: return "Evaluating rule";
+        case PCC_DBG_MATCH: return "Matched rule";
+        case PCC_DBG_NOMATCH: return "Abandoning rule";
+        default: return "Unknown event";
+    }
+};
+#define PCC_DEBUG(event, rule, level, pos, length, buffer) \
+    fprintf(stderr, "%*s%s %s @%d [%.*s]\n", level * 2, "", dbg_str(event), rule, pos, length, buffer)
+```
+
+The default is to do nothing:
+```C
+#define PCC_DEBUG(event, rule, level, pos, buffer, length) ((void)0)
+```
+
 **`PCC_BUFFERSIZE`**
 
 The initial size (the number of characters) of the text buffer. The text buffer is expanded as needed. The default is `256`.

--- a/tests/debug_macro.d/expected.txt
+++ b/tests/debug_macro.d/expected.txt
@@ -1,0 +1,64 @@
+Evaluating rule TOP @0 []
+  Evaluating rule RULE_A @0 []
+  Matched rule RULE_A @0 [Aaa]
+  Evaluating rule EOL @3 [
+]
+  Matched rule EOL @3 [
+]
+Matched rule TOP @0 [Aaa
+]
+Evaluating rule TOP @0 [B]
+  Evaluating rule RULE_A @0 [B]
+  Abandoning rule RULE_A @0 []
+  Evaluating rule RULE_B @0 [B]
+    Evaluating rule RULE_B1 @0 [B]
+      Evaluating rule RULE_A @2 [C]
+      Abandoning rule RULE_A @2 []
+    Abandoning rule RULE_B1 @0 [BB]
+    Evaluating rule RULE_B2 @0 [BBC]
+      Evaluating rule RULE_C @2 [C]
+        Evaluating rule RULE_A @5 [b]
+        Abandoning rule RULE_A @5 []
+        Evaluating rule RULE_B @5 [b]
+          Evaluating rule RULE_B1 @5 [b]
+            Evaluating rule RULE_A @7 [C]
+            Abandoning rule RULE_A @7 []
+          Abandoning rule RULE_B1 @5 [bb]
+          Evaluating rule RULE_B2 @5 [bbC]
+            Evaluating rule RULE_C @7 [C]
+              Evaluating rule RULE_A @9 [B]
+              Abandoning rule RULE_A @9 []
+              Evaluating rule RULE_B @9 [B]
+                Evaluating rule RULE_B1 @9 [B]
+                  Evaluating rule RULE_A @13 [
+]
+                  Abandoning rule RULE_A @13 []
+                Abandoning rule RULE_B1 @9 [Bbbb]
+                Evaluating rule RULE_B2 @9 [Bbbb
+]
+                  Evaluating rule RULE_C @13 [
+]
+                  Abandoning rule RULE_C @13 []
+                Matched rule RULE_B2 @9 [Bbbb]
+              Matched rule RULE_B @9 [Bbbb]
+            Matched rule RULE_C @7 [CCBbbb]
+          Matched rule RULE_B2 @5 [bbCCBbbb]
+        Matched rule RULE_B @5 [bbCCBbbb]
+      Matched rule RULE_C @2 [CccbbCCBbbb]
+    Matched rule RULE_B2 @0 [BBCccbbCCBbbb]
+  Matched rule RULE_B @0 [BBCccbbCCBbbb]
+  Evaluating rule EOL @13 [
+]
+  Matched rule EOL @13 [
+]
+Matched rule TOP @0 [BBCccbbCCBbbb
+]
+A: Aaa
+B2: Bbbb
+B: Bbbb
+C: CCBbbb
+B2: bbCCBbbb
+B: bbCCBbbb
+C: CccbbCCBbbb
+B2: BBCccbbCCBbbb
+B: BBCccbbCCBbbb

--- a/tests/debug_macro.d/input.peg
+++ b/tests/debug_macro.d/input.peg
@@ -1,0 +1,20 @@
+%source {
+static const char *dbg_str(int event) {
+    switch(event) {
+        case PCC_DBG_EVALUATE: return "Evaluating rule";
+        case PCC_DBG_MATCH: return "Matched rule";
+        case PCC_DBG_NOMATCH: return "Abandoning rule";
+        default: return "Unknown event";
+    }
+};
+#define PCC_DEBUG(event, rule, level, pos, buffer, length) \
+    fprintf(stderr, "%*s%s %s @%d [%.*s]\n", level * 2, "", dbg_str(event), rule, pos, length, buffer)
+}
+
+TOP <- (RULE_A / RULE_B) EOL
+RULE_A <- [Aa]+                     { PRINT_L("A", $0); }
+RULE_B <- RULE_B1 / RULE_B2         { PRINT_L("B", $0); }
+RULE_B1 <- [Bb]+ RULE_A             { PRINT_L("B1", $0); }
+RULE_B2 <- [Bb]+ RULE_C?            { PRINT_L("B2", $0); }
+RULE_C <- [Cc]+ (RULE_A / RULE_B)   { PRINT_L("C", $0); }
+EOL <- "\n"

--- a/tests/debug_macro.d/input.txt
+++ b/tests/debug_macro.d/input.txt
@@ -1,0 +1,2 @@
+Aaa
+BBCccbbCCBbbb

--- a/tests/main.c
+++ b/tests/main.c
@@ -3,6 +3,7 @@
 #include "parser.h"
 
 #define PRINT(X) printf("%s\n", X);
+#define PRINT_L(LBL, X) printf("%s: %s\n", LBL, X);
 
 #ifndef RET_TYPE
 #define RET_TYPE int


### PR DESCRIPTION
When I was developing Kotlin parser, I found it very difficult to debug errors in grammar, since the only clue I had was whether some input can be parsed or not. This proposal adds a new macro PCC_DEBUG, that can be used to emit trace of the parsing process, which simplifies the debugging tremendously. 