### PR TITLE
U-Ctags related changes

### DIFF
--- a/src/packcc.c
+++ b/src/packcc.c
@@ -46,7 +46,7 @@
 #include <assert.h>
 
 #ifndef _MSC_VER
-#if defined __GNUC__ && defined _WIN32 /* MinGW */
+#if ((defined USE_SYSTEM_STRNLEN) == 0) && defined __GNUC__ && defined _WIN32 /* MinGW */
 #define strnlen(str, maxlen) strnlen_(str, maxlen)
 static size_t strnlen_(const char *str, size_t maxlen) {
     size_t i;

--- a/src/packcc.c
+++ b/src/packcc.c
@@ -2305,7 +2305,7 @@ static bool_t parse(context_t *ctx) {
             "#include <string.h>\n"
             "\n"
             "#ifndef _MSC_VER\n"
-            "#if defined __GNUC__ && defined _WIN32 /* MinGW */\n"
+            "#if ((defined USE_SYSTEM_STRNLEN) == 0) && defined __GNUC__ && defined _WIN32 /* MinGW */\n"
             "#define strnlen(str, maxlen) pcc_strnlen(str, maxlen)\n"
             "static size_t pcc_strnlen(const char *str, size_t maxlen) {\n"
             "    size_t i;\n"


### PR DESCRIPTION
Cherry-picked changes from https://github.com/enechaev/packcc, required for [universal ctags](https://github.com/universal-ctags/ctags) to work correctly.

See also #25.