### PR TITLE
`#ifndef __has_attribute` instead of invalid `#ifndef __attribute__`

### DIFF
--- a/src/packcc.c
+++ b/src/packcc.c
@@ -285,7 +285,8 @@ typedef enum code_reach_tag {
 
 static const char *g_cmdname = "packcc"; /* replaced later with actual one */
 
-static int print_error(const char *format, ...) __attribute__((format(printf, 1, 2))) {
+__attribute__((format(printf, 1, 2)))
+static int print_error(const char *format, ...) {
     int n;
     va_list a;
     va_start(a, format);
@@ -352,7 +353,8 @@ static int fputs_e(const char *s, FILE *stream) {
     return r;
 }
 
-static int fprintf_e(FILE *stream, const char *format, ...) __attribute__((format(printf, 2, 3))) {
+__attribute__((format(printf, 2, 3)))
+static int fprintf_e(FILE *stream, const char *format, ...) {
     int n;
     va_list a;
     va_start(a, format);

--- a/src/packcc.c
+++ b/src/packcc.c
@@ -64,7 +64,7 @@ static size_t strnlen_(const char *str, size_t maxlen) {
 #include <unistd.h> /* for unlink() */
 #endif
 
-#ifndef __attribute__
+#ifndef __has_attribute
 #define __attribute__(x)
 #endif
 


### PR DESCRIPTION
`__attribute__` is not a macro, so `__attribute__(xxx)` was always
expanded to `` even on gcc having xxx.

Refference:
https://github.com/abseil/abseil-cpp/blob/20210324.2/absl/base/attributes.h#L39-L53
