### PR TITLE
draft: optimization

### DIFF
--- a/tests/benchmark/.gitignore
+++ b/tests/benchmark/.gitignore
@@ -1,0 +1,3 @@
+parser_*
+dump_*
+*.out

--- a/tests/benchmark/benchmark.sh
+++ b/tests/benchmark/benchmark.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+
+build() {
+    if [ -z "$PACKCC" ]; then
+        export PACKCC="$BENCHDIR/packcc"
+        echo "Building packcc..."
+        ${CC:-cc -O2} -o "$PACKCC" $ROOTDIR/src/packcc.c
+    fi
+}
+
+clean() {
+    rm -f packcc parser* *.out
+}
+
+format() {
+    TIME="$1"
+    if [ $(($TIME / 1000000000)) -gt 10 ]; then
+        echo "$(($TIME / 1000000000)) s"
+    elif [ $(($TIME / 1000000)) -gt 10 ]; then
+        echo "$(($TIME / 1000000)) ms"
+    elif [ $(($TIME / 1000)) -gt 10 ]; then
+        echo "$(($TIME / 1000)) us"
+    else
+        echo "$(($TIME)) ns"
+    fi
+}
+
+measure() {
+    COUNT="$1"
+    shift
+    START="$(date '+%s%N')"
+    for ((i=0; i<$COUNT; i++)); do
+        "$@"
+    done
+    END="$(date '+%s%N')"
+    TIME=$(( $END - $START ))
+}
+
+benchmark() {
+    KEY="$1"
+    BENCHMARKS+=("$KEY")
+    shift
+    NAME="parser_$KEY"
+
+    echo "Generating $KEY parser ($GEN_REPEATS times)..."
+    "$PACKCC" --debug "$@" -o "$NAME" "$GRAMMAR" > "dump_$KEY.log"
+    measure $GEN_REPEATS "$PACKCC" "$@" -o "$NAME" "$GRAMMAR"
+    GENERATION["$KEY"]=$TIME
+    echo "  Repeated $GEN_REPEATS times in $(format $TIME)"
+
+    echo "Building $KEY parser..."
+    measure $BUILD_REPEATS ${CC:-cc -O2} "$NAME".c -o "$NAME"
+    BUILD["$KEY"]=$TIME
+    echo "  Built $BUILD_REPEATS times in $(format $TIME)"
+
+    echo "Running $KEY parser ($REPEATS times)..."
+    "./$NAME" < "$INPUT" &> "$KEY.out"
+    measure $REPEATS "./$NAME" < "$INPUT" &> /dev/null
+    RESULTS["$KEY"]=$TIME
+    echo "  Repeated $REPEATS times in $(format $TIME)"
+}
+
+print_results() {
+    TAB=$'\t'
+    FORMAT="%-12s %-15s %-15s %-15s %8s %8s\n"
+    printf "\n$FORMAT" "Test" "Generation" "Build" "Run" "Rules" "Diff?"
+    for KEY in "${BENCHMARKS[@]}"; do
+        DIFF="$(diff "base.out" "$KEY.out" | grep -c '^[<>]' || true)"
+        RELATIVE="$((100*RESULTS["$KEY"]/RESULTS[base]))"
+        AVG="$((RESULTS["$KEY"]/$REPEATS))"
+        GEN_AVG="$((GENERATION["$KEY"]/$GEN_REPEATS))"
+        GEN_RELATIVE="$((100*GENERATION["$KEY"]/${GENERATION[base]}))"
+        BUILD_AVG="$((BUILD["$KEY"]/$BUILD_REPEATS))"
+        BUILD_RELATIVE="$((100*BUILD["$KEY"]/${BUILD[base]}))"
+        RULES="$(grep -c '^Rule(' "dump_$KEY.log")"
+        printf "$FORMAT" "$KEY" "$(format $GEN_AVG) ($GEN_RELATIVE%)" "$(format $BUILD_AVG) ($BUILD_RELATIVE%)" "$(format $AVG) ($RELATIVE%)" "$RULES" "$DIFF"
+    done
+}
+
+main() {
+    set -e
+
+    export BENCHDIR="$(cd "$(dirname "$0")" && pwd)"
+    export ROOTDIR="$BENCHDIR/../.."
+    declare -a BENCHMARKS=()
+    declare -A RESULTS=()
+    declare -A GENERATION=()
+
+    REPEATS="${REPEATS:-100}"
+    GEN_REPEATS="${GEN_REPEATS:-100}"
+    BUILD_REPEATS="${BUILD_REPEATS:-3}"
+    GRAMMAR="${GRAMMAR:-kotlin.peg}"
+    INPUT="${INPUT:-input.kt}"
+
+    cd "$BENCHDIR"
+    clean
+    build
+
+    benchmark base
+    benchmark inline -O 1
+    benchmark concat -O 2
+    benchmark all -O 1 -O 2
+
+    print_results
+}
+
+main "$@"

--- a/tests/benchmark/input.kt
+++ b/tests/benchmark/input.kt
@@ -1,0 +1,1990 @@
+/*
+ * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.fir.builder
+
+import com.intellij.psi.PsiElement
+import com.intellij.psi.tree.IElementType
+import org.jetbrains.kotlin.descriptors.ClassKind
+import org.jetbrains.kotlin.descriptors.Modality
+import org.jetbrains.kotlin.descriptors.Visibilities
+import org.jetbrains.kotlin.descriptors.Visibility
+import org.jetbrains.kotlin.fir.*
+import org.jetbrains.kotlin.fir.contracts.FirContractDescription
+import org.jetbrains.kotlin.fir.contracts.builder.buildRawContractDescription
+import org.jetbrains.kotlin.fir.declarations.*
+import org.jetbrains.kotlin.fir.declarations.builder.*
+import org.jetbrains.kotlin.fir.declarations.impl.FirDeclarationStatusImpl
+import org.jetbrains.kotlin.fir.declarations.impl.FirDefaultPropertyAccessor
+import org.jetbrains.kotlin.fir.declarations.impl.FirDefaultPropertyGetter
+import org.jetbrains.kotlin.fir.declarations.impl.FirDefaultPropertySetter
+import org.jetbrains.kotlin.fir.diagnostics.ConeSimpleDiagnostic
+import org.jetbrains.kotlin.fir.diagnostics.DiagnosticKind
+import org.jetbrains.kotlin.fir.expressions.*
+import org.jetbrains.kotlin.fir.expressions.builder.*
+import org.jetbrains.kotlin.fir.expressions.impl.FirSingleExpressionBlock
+import org.jetbrains.kotlin.fir.references.FirNamedReference
+import org.jetbrains.kotlin.fir.references.builder.*
+import org.jetbrains.kotlin.fir.scopes.FirScopeProvider
+import org.jetbrains.kotlin.fir.symbols.AbstractFirBasedSymbol
+import org.jetbrains.kotlin.fir.symbols.CallableId
+import org.jetbrains.kotlin.fir.symbols.impl.*
+import org.jetbrains.kotlin.fir.types.*
+import org.jetbrains.kotlin.fir.types.builder.*
+import org.jetbrains.kotlin.fir.types.impl.ConeClassLikeTypeImpl
+import org.jetbrains.kotlin.fir.types.impl.FirQualifierPartImpl
+import org.jetbrains.kotlin.fir.types.impl.FirTypeArgumentListImpl
+import org.jetbrains.kotlin.fir.types.impl.FirTypePlaceholderProjection
+import org.jetbrains.kotlin.lexer.KtTokens.*
+import org.jetbrains.kotlin.name.ClassId
+import org.jetbrains.kotlin.name.Name
+import org.jetbrains.kotlin.psi.*
+import org.jetbrains.kotlin.psi.psiUtil.*
+import org.jetbrains.kotlin.types.Variance
+import org.jetbrains.kotlin.types.expressions.OperatorConventions
+import org.jetbrains.kotlin.util.OperatorNameConventions
+import org.jetbrains.kotlin.utils.addToStdlib.firstIsInstanceOrNull
+import org.jetbrains.kotlin.utils.addToStdlib.runIf
+import java.util.*
+
+class RawFirBuilder(
+    session: FirSession, val baseScopeProvider: FirScopeProvider, val stubMode: Boolean
+) : BaseFirBuilder<PsiElement>(session) {
+
+    fun buildFirFile(file: KtFile): FirFile {
+        return file.accept(Visitor(), Unit) as FirFile
+    }
+
+    fun buildTypeReference(reference: KtTypeReference): FirTypeRef {
+        return reference.accept(Visitor(), Unit) as FirTypeRef
+    }
+
+    fun buildFunctionWithBody(function: KtNamedFunction): FirFunction<*> {
+        assert(!stubMode) { "Building FIR function with body isn't supported in stub mode" }
+        val parentsUpToFile = function.parents
+        for (parent in parentsUpToFile.toList().asReversed()) {
+            when (parent) {
+                is KtFile -> {
+                    context.packageFqName = parent.packageFqName
+                }
+                is KtClassOrObject -> {
+                    context.className = context.className.child(parent.nameAsSafeName)
+                    context.localBits.add(parent.isLocal || parent.getStrictParentOfType<KtEnumEntry>() != null)
+                }
+            }
+        }
+        return function.accept(Visitor(), Unit) as FirFunction<*>
+    }
+
+    override fun PsiElement.toFirSourceElement(kind: FirFakeSourceElementKind?): FirPsiSourceElement<*> {
+        val actualKind = kind ?: this@RawFirBuilder.context.forcedElementSourceKind ?: FirRealSourceElementKind
+        return this.toFirPsiSourceElement(actualKind)
+    }
+
+    override val PsiElement.elementType: IElementType
+        get() = node.elementType
+
+    override val PsiElement.asText: String
+        get() = text
+
+    override val PsiElement.unescapedValue: String
+        get() = (this as KtEscapeStringTemplateEntry).unescapedValue
+
+    override fun PsiElement.getChildNodeByType(type: IElementType): PsiElement? {
+        return children.firstOrNull { it.node.elementType == type }
+    }
+
+    override fun PsiElement.getReferencedNameAsName(): Name {
+        return (this as KtSimpleNameExpression).getReferencedNameAsName()
+    }
+
+    override fun PsiElement.getLabelName(): String? {
+        return (this as? KtExpressionWithLabel)?.getLabelName()
+    }
+
+    override fun PsiElement.getExpressionInParentheses(): PsiElement? {
+        return (this as KtParenthesizedExpression).expression
+    }
+
+    override fun PsiElement.getAnnotatedExpression(): PsiElement? {
+        return (this as KtAnnotatedExpression).baseExpression
+    }
+
+    override val PsiElement?.selectorExpression: PsiElement?
+        get() = (this as? KtQualifiedExpression)?.selectorExpression
+
+    private val KtModifierListOwner.visibility: Visibility
+        get() = with(modifierList) {
+            when {
+                this == null -> Visibilities.Unknown
+                hasModifier(PRIVATE_KEYWORD) -> Visibilities.Private
+                hasModifier(PUBLIC_KEYWORD) -> Visibilities.Public
+                hasModifier(PROTECTED_KEYWORD) -> Visibilities.Protected
+                else -> if (hasModifier(INTERNAL_KEYWORD)) Visibilities.Internal else Visibilities.Unknown
+            }
+        }
+
+    private val KtDeclaration.modality: Modality?
+        get() = with(modifierList) {
+            when {
+                this == null -> null
+                hasModifier(FINAL_KEYWORD) -> Modality.FINAL
+                hasModifier(SEALED_KEYWORD) -> Modality.SEALED
+                hasModifier(ABSTRACT_KEYWORD) -> Modality.ABSTRACT
+                else -> if (hasModifier(OPEN_KEYWORD)) Modality.OPEN else null
+            }
+        }
+
+    private inner class Visitor : KtVisitor<FirElement, Unit>() {
+        private inline fun <reified R : FirElement> KtElement?.convertSafe(): R? =
+            this?.accept(this@Visitor, Unit) as? R
+
+        private inline fun <reified R : FirElement> KtElement.convert(): R =
+            this.accept(this@Visitor, Unit) as R
+
+        private fun KtTypeReference?.toFirOrImplicitType(): FirTypeRef =
+            convertSafe() ?: buildImplicitTypeRef {
+                source = this@toFirOrImplicitType?.toFirSourceElement(FirFakeSourceElementKind.ImplicitTypeRef)
+            }
+
+        private fun KtTypeReference?.toFirOrUnitType(): FirTypeRef =
+            convertSafe() ?: implicitUnitType
+
+        private fun KtTypeReference?.toFirOrErrorType(): FirTypeRef =
+            convertSafe() ?: buildErrorTypeRef {
+                source = this@toFirOrErrorType?.toFirSourceElement()
+                diagnostic = ConeSimpleDiagnostic(
+                    if (this@toFirOrErrorType == null) "Incomplete code" else "Conversion failed", DiagnosticKind.Syntax
+                )
+            }
+
+        // Here we accept lambda as receiver to prevent expression calculation in stub mode
+        private fun (() -> KtExpression?).toFirExpression(errorReason: String): FirExpression =
+            if (stubMode) buildExpressionStub()
+            else with(this()) {
+                convertSafe() ?: buildErrorExpression(
+                    this?.toFirSourceElement(), ConeSimpleDiagnostic(errorReason, DiagnosticKind.ExpressionRequired),
+                )
+            }
+
+        private fun KtExpression?.toFirExpression(errorReason: String): FirExpression =
+            if (stubMode) buildExpressionStub()
+            else convertSafe() ?: buildErrorExpression(
+                this?.toFirSourceElement(), ConeSimpleDiagnostic(errorReason, DiagnosticKind.ExpressionRequired),
+            )
+
+        private fun KtExpression.toFirStatement(errorReason: String): FirStatement =
+            convertSafe() ?: buildErrorExpression(this.toFirSourceElement(), ConeSimpleDiagnostic(errorReason, DiagnosticKind.Syntax))
+
+        private fun KtExpression.toFirStatement(): FirStatement =
+            convert()
+
+        private fun KtDeclaration.toFirDeclaration(
+            delegatedSuperType: FirTypeRef,
+            delegatedSelfType: FirResolvedTypeRef,
+            owner: KtClassOrObject,
+            ownerClassBuilder: FirClassBuilder,
+            ownerTypeParameters: List<FirTypeParameterRef>
+        ): FirDeclaration {
+            return when (this) {
+                is KtSecondaryConstructor -> {
+                    toFirConstructor(
+                        delegatedSuperType,
+                        delegatedSelfType,
+                        owner,
+                        ownerTypeParameters
+                    )
+                }
+                is KtEnumEntry -> {
+                    val primaryConstructor = owner.primaryConstructor
+                    val ownerClassHasDefaultConstructor =
+                        primaryConstructor?.valueParameters?.isEmpty() ?: owner.secondaryConstructors.let { constructors ->
+                            constructors.isEmpty() || constructors.any { it.valueParameters.isEmpty() }
+                        }
+                    toFirEnumEntry(delegatedSelfType, ownerClassHasDefaultConstructor)
+                }
+                is KtProperty -> {
+                    toFirProperty(ownerClassBuilder)
+                }
+                else -> convert()
+            }
+        }
+
+        private fun KtExpression?.toFirBlock(): FirBlock =
+            when (this) {
+                is KtBlockExpression ->
+                    accept(this@Visitor, Unit) as FirBlock
+                null ->
+                    buildEmptyExpressionBlock()
+                else ->
+                    FirSingleExpressionBlock(convert())
+            }
+
+        private fun KtDeclarationWithBody.buildFirBody(): Pair<FirBlock?, FirContractDescription?> =
+            when {
+                !hasBody() ->
+                    null to null
+                hasBlockBody() -> if (!stubMode) {
+                    val block = bodyBlockExpression?.accept(this@Visitor, Unit) as? FirBlock
+                    if (hasContractEffectList()) {
+                        block to null
+                    } else {
+                        block.extractContractDescriptionIfPossible()
+                    }
+                } else {
+                    FirSingleExpressionBlock(buildExpressionStub { source = this@buildFirBody.toFirSourceElement() }.toReturn()) to null
+                }
+                else -> {
+                    val result = { bodyExpression }.toFirExpression("Function has no body (but should)")
+                    FirSingleExpressionBlock(result.toReturn(baseSource = result.source)) to null
+                }
+            }
+
+        private fun ValueArgument?.toFirExpression(): FirExpression {
+            if (this == null) {
+                return buildErrorExpression(
+                    (this as? KtElement)?.toFirSourceElement(),
+                    ConeSimpleDiagnostic("No argument given", DiagnosticKind.Syntax),
+                )
+            }
+            val name = this.getArgumentName()?.asName
+            val expression = this.getArgumentExpression()
+            val firExpression = when (expression) {
+                is KtConstantExpression, is KtStringTemplateExpression -> {
+                    expression.accept(this@Visitor, Unit) as FirExpression
+                }
+
+                else -> {
+                    { expression }.toFirExpression("Argument is absent")
+                }
+            }
+            val isSpread = getSpreadElement() != null
+            return when {
+                name != null -> buildNamedArgumentExpression {
+                    source = (this@toFirExpression as? PsiElement)?.toFirSourceElement()
+                    this.expression = firExpression
+                    this.isSpread = isSpread
+                    this.name = name
+                }
+                isSpread -> buildSpreadArgumentExpression {
+                    source = (this@toFirExpression as? PsiElement)?.toFirSourceElement()
+                    this.expression = firExpression
+                }
+                else -> firExpression
+            }
+        }
+
+        private fun KtPropertyAccessor?.toFirPropertyAccessor(
+            property: KtProperty,
+            propertyTypeRef: FirTypeRef,
+            isGetter: Boolean,
+        ): FirPropertyAccessor {
+            val accessorVisibility =
+                if (this?.visibility != null && this.visibility != Visibilities.Unknown) this.visibility else property.visibility
+            // Downward propagation of `inline` and `external` modifiers (from property to its accessors)
+            val status =
+                FirDeclarationStatusImpl(accessorVisibility, Modality.FINAL).apply {
+                    isInline = property.hasModifier(INLINE_KEYWORD) ||
+                            this@toFirPropertyAccessor?.hasModifier(INLINE_KEYWORD) == true
+                    isExternal = property.hasModifier(EXTERNAL_KEYWORD) ||
+                            this@toFirPropertyAccessor?.hasModifier(EXTERNAL_KEYWORD) == true
+                }
+            if (this == null || !hasBody()) {
+                val propertySource =
+                    if (this != null && hasBody()) property.toFirSourceElement()
+                    else property.toFirPsiSourceElement(FirFakeSourceElementKind.DefaultAccessor)
+                return FirDefaultPropertyAccessor
+                    .createGetterOrSetter(
+                        propertySource,
+                        baseSession,
+                        FirDeclarationOrigin.Source,
+                        propertyTypeRef,
+                        accessorVisibility,
+                        isGetter
+                    )
+                    .also {
+                        if (this != null) {
+                            it.extractAnnotationsFrom(this)
+                        }
+                        it.status = status
+                    }
+            }
+            val source = this.toFirSourceElement()
+            val accessorTarget = FirFunctionTarget(labelName = null, isLambda = false)
+            return buildPropertyAccessor {
+                this.source = source
+                session = baseSession
+                origin = FirDeclarationOrigin.Source
+                returnTypeRef = if (isGetter) {
+                    returnTypeReference?.convertSafe() ?: propertyTypeRef
+                } else {
+                    returnTypeReference.toFirOrUnitType()
+                }
+                this.isGetter = isGetter
+                this.status = status
+                extractAnnotationsTo(this)
+                this@RawFirBuilder.context.firFunctionTargets += accessorTarget
+                extractValueParametersTo(this, propertyTypeRef)
+                if (!isGetter && valueParameters.isEmpty()) {
+                    valueParameters += buildDefaultSetterValueParameter {
+                        this.source = source.fakeElement(FirFakeSourceElementKind.DefaultAccessor)
+                        session = baseSession
+                        origin = FirDeclarationOrigin.Source
+                        returnTypeRef = propertyTypeRef
+                        symbol = FirVariableSymbol(NAME_FOR_DEFAULT_VALUE_PARAMETER)
+                    }
+                }
+                symbol = FirPropertyAccessorSymbol()
+                val outerContractDescription = this@toFirPropertyAccessor.obtainContractDescription()
+                val bodyWithContractDescription = this@toFirPropertyAccessor.buildFirBody()
+                this.body = bodyWithContractDescription.first
+                val contractDescription = outerContractDescription ?: bodyWithContractDescription.second
+                contractDescription?.let {
+                    this.contractDescription = it
+                }
+            }.also {
+                accessorTarget.bind(it)
+                this@RawFirBuilder.context.firFunctionTargets.removeLast()
+            }
+        }
+
+        private fun KtParameter.toFirValueParameter(defaultTypeRef: FirTypeRef? = null): FirValueParameter {
+            val name = nameAsSafeName
+            return buildValueParameter {
+                source = toFirSourceElement()
+                session = baseSession
+                origin = FirDeclarationOrigin.Source
+                returnTypeRef = when {
+                    typeReference != null -> typeReference.toFirOrErrorType()
+                    defaultTypeRef != null -> defaultTypeRef
+                    else -> null.toFirOrImplicitType()
+                }
+                this.name = name
+                symbol = FirVariableSymbol(name)
+                defaultValue = if (hasDefaultValue()) {
+                    { this@toFirValueParameter.defaultValue }.toFirExpression("Should have default value")
+                } else null
+                isCrossinline = hasModifier(CROSSINLINE_KEYWORD)
+                isNoinline = hasModifier(NOINLINE_KEYWORD)
+                isVararg = isVarArg
+                extractAnnotationsTo(this)
+            }
+        }
+
+        private fun KtParameter.toFirProperty(firParameter: FirValueParameter, isExpect: Boolean): FirProperty {
+            require(hasValOrVar())
+            val type = typeReference.toFirOrErrorType()
+            val status = FirDeclarationStatusImpl(visibility, modality).apply {
+                this.isExpect = isExpect
+                isActual = hasActualModifier()
+                isOverride = hasModifier(OVERRIDE_KEYWORD)
+                isConst = false
+                isLateInit = false
+            }
+            val propertySource = toFirSourceElement(FirFakeSourceElementKind.PropertyFromParameter)
+            val propertyName = nameAsSafeName
+            return buildProperty {
+                source = propertySource
+                session = baseSession
+                origin = FirDeclarationOrigin.Source
+                returnTypeRef = type.copyWithNewSourceKind(FirFakeSourceElementKind.PropertyFromParameter)
+                receiverTypeRef = null
+                name = propertyName
+                initializer = buildQualifiedAccessExpression {
+                    source = propertySource
+                    calleeReference = buildPropertyFromParameterResolvedNamedReference {
+                        source = propertySource
+                        name = propertyName
+                        resolvedSymbol = firParameter.symbol
+                    }
+                }
+                isVar = isMutable
+                symbol = FirPropertySymbol(callableIdForName(propertyName))
+                isLocal = false
+                this.status = status
+                val defaultAccessorSource = propertySource.fakeElement(FirFakeSourceElementKind.DefaultAccessor)
+                getter = FirDefaultPropertyGetter(
+                    defaultAccessorSource,
+                    baseSession,
+                    FirDeclarationOrigin.Source,
+                    type.copyWithNewSourceKind(FirFakeSourceElementKind.DefaultAccessor),
+                    visibility
+                )
+                setter = if (isMutable) FirDefaultPropertySetter(
+                    defaultAccessorSource,
+                    baseSession,
+                    FirDeclarationOrigin.Source,
+                    type.copyWithNewSourceKind(FirFakeSourceElementKind.DefaultAccessor),
+                    visibility
+                ) else null
+                extractAnnotationsTo(this)
+            }.apply {
+                isFromVararg = firParameter.isVararg
+            }
+        }
+
+        private fun FirDefaultPropertyAccessor.extractAnnotationsFrom(annotated: KtAnnotated) {
+            annotated.extractAnnotationsTo(this.annotations)
+        }
+
+        private fun KtAnnotated.extractAnnotationsTo(container: MutableList<FirAnnotationCall>) {
+            for (annotationEntry in annotationEntries) {
+                container += annotationEntry.convert<FirAnnotationCall>()
+            }
+        }
+
+        private fun KtAnnotated.extractAnnotationsTo(container: FirAnnotationContainerBuilder) {
+            extractAnnotationsTo(container.annotations)
+        }
+
+        private fun KtTypeParameterListOwner.extractTypeParametersTo(container: FirTypeParameterRefsOwnerBuilder) {
+            for (typeParameter in typeParameters) {
+                container.typeParameters += typeParameter.convert<FirTypeParameter>()
+            }
+        }
+
+        private fun KtTypeParameterListOwner.extractTypeParametersTo(container: FirTypeParametersOwnerBuilder) {
+            for (typeParameter in typeParameters) {
+                container.typeParameters += typeParameter.convert<FirTypeParameter>()
+            }
+        }
+
+        private fun KtDeclarationWithBody.extractValueParametersTo(
+            container: FirFunctionBuilder,
+            defaultTypeRef: FirTypeRef? = null,
+        ) {
+            for (valueParameter in valueParameters) {
+                container.valueParameters += valueParameter.toFirValueParameter(defaultTypeRef)
+            }
+        }
+
+        private fun KtCallElement.extractArgumentsTo(container: FirCallBuilder) {
+            val argumentList = buildArgumentList {
+                for (argument in valueArguments) {
+                    val argumentExpression = argument.toFirExpression()
+                    arguments += when (argument) {
+                        is KtLambdaArgument -> buildLambdaArgumentExpression {
+                            source = argument.toFirSourceElement()
+                            expression = argumentExpression
+                        }
+                        else -> argumentExpression
+                    }
+                }
+            }
+            container.argumentList = argumentList
+        }
+
+        private fun KtClassOrObject.extractSuperTypeListEntriesTo(
+            container: FirClassBuilder,
+            delegatedSelfTypeRef: FirTypeRef?,
+            delegatedEnumSuperTypeRef: FirTypeRef?,
+            classKind: ClassKind,
+            containerTypeParameters: List<FirTypeParameterRef>,
+            containerSymbol: AbstractFirBasedSymbol<*>
+        ): FirTypeRef {
+            var superTypeCallEntry: KtSuperTypeCallEntry? = null
+            var delegatedSuperTypeRef: FirTypeRef? = null
+            var delegateNumber = 0
+            val initializeDelegateStatements = mutableListOf<FirStatement>()
+            for (superTypeListEntry in superTypeListEntries) {
+                when (superTypeListEntry) {
+                    is KtSuperTypeEntry -> {
+                        container.superTypeRefs += superTypeListEntry.typeReference.toFirOrErrorType()
+                    }
+                    is KtSuperTypeCallEntry -> {
+                        delegatedSuperTypeRef = superTypeListEntry.calleeExpression.typeReference.toFirOrErrorType()
+                        container.superTypeRefs += delegatedSuperTypeRef
+                        superTypeCallEntry = superTypeListEntry
+                    }
+                    is KtDelegatedSuperTypeEntry -> {
+                        val type = superTypeListEntry.typeReference.toFirOrErrorType()
+                        val delegateExpression = { superTypeListEntry.delegateExpression }.toFirExpression("Should have delegate")
+                        container.superTypeRefs += type
+                        val delegateName = Name.special("<\$\$delegate_$delegateNumber>")
+                        val delegateSource = superTypeListEntry.delegateExpression?.toFirSourceElement()
+                        val delegateField = buildField {
+                            source = delegateSource
+                            session = baseSession
+                            origin = FirDeclarationOrigin.Synthetic
+                            name = delegateName
+                            returnTypeRef = type
+                            symbol = FirFieldSymbol(CallableId(name))
+                            isVar = false
+                            status = FirDeclarationStatusImpl(Visibilities.Local, Modality.FINAL)
+                        }
+                        initializeDelegateStatements.add(
+                            buildVariableAssignment {
+                                source = delegateSource
+                                calleeReference =
+                                    buildResolvedNamedReference {
+                                        name = delegateName
+                                        resolvedSymbol = delegateField.symbol
+                                    }
+                                rValue = delegateExpression
+                                dispatchReceiver = buildThisReceiverExpression {
+                                    calleeReference = buildImplicitThisReference {
+                                        boundSymbol = containerSymbol
+                                    }
+                                    delegatedSelfTypeRef?.let { typeRef = it }
+                                }
+                            }
+                        )
+                        container.declarations.add(delegateField)
+                        delegateNumber ++
+                    }
+                }
+            }
+
+            when {
+                this is KtClass && classKind == ClassKind.ENUM_CLASS -> {
+                    /*
+                     * kotlin.Enum constructor has (name: String, ordinal: Int) signature,
+                     *   so we should generate non-trivial constructors for enum and it's entry
+                     *   for correct resolve of super constructor call or just call kotlin.Any constructor
+                     *   and convert it to right call at backend, because of it doesn't affects frontend work
+                     */
+                    delegatedSuperTypeRef = buildResolvedTypeRef {
+                        type = ConeClassLikeTypeImpl(
+                            implicitEnumType.type.lookupTag,
+                            delegatedSelfTypeRef?.coneType?.let { arrayOf(it) } ?: emptyArray(),
+                            isNullable = false,
+                        )
+                    }
+                    container.superTypeRefs += delegatedSuperTypeRef
+                }
+                this is KtClass && classKind == ClassKind.ANNOTATION_CLASS -> {
+                    container.superTypeRefs += implicitAnnotationType
+                    delegatedSuperTypeRef = implicitAnyType
+                }
+            }
+
+            val defaultDelegatedSuperTypeRef =
+                when {
+                    classKind == ClassKind.ENUM_ENTRY && this is KtClass -> delegatedEnumSuperTypeRef ?: implicitAnyType
+                    container.superTypeRefs.isEmpty() -> implicitAnyType
+                    else -> buildImplicitTypeRef()
+                }
+
+
+            if (container.superTypeRefs.isEmpty()) {
+                container.superTypeRefs += implicitAnyType
+                delegatedSuperTypeRef = implicitAnyType
+            }
+            if (this is KtClass && this.isInterface()) return delegatedSuperTypeRef ?: implicitAnyType
+
+            // TODO: in case we have no primary constructor,
+            // it may be not possible to determine delegated super type right here
+            delegatedSuperTypeRef = delegatedSuperTypeRef ?: defaultDelegatedSuperTypeRef
+            if (!this.hasPrimaryConstructor()) return delegatedSuperTypeRef
+
+            val firPrimaryConstructor = primaryConstructor.toFirConstructor(
+                superTypeCallEntry,
+                delegatedSuperTypeRef,
+                delegatedSelfTypeRef ?: delegatedSuperTypeRef,
+                owner = this,
+                containerTypeParameters,
+                body = if (initializeDelegateStatements.isNotEmpty()) buildBlock {
+                    for (statement in initializeDelegateStatements) {
+                        statements += statement
+                    }
+                } else null
+            )
+
+            container.declarations += firPrimaryConstructor
+            return delegatedSuperTypeRef
+        }
+
+        private fun KtPrimaryConstructor?.toFirConstructor(
+            superTypeCallEntry: KtSuperTypeCallEntry?,
+            delegatedSuperTypeRef: FirTypeRef,
+            delegatedSelfTypeRef: FirTypeRef,
+            owner: KtClassOrObject,
+            ownerTypeParameters: List<FirTypeParameterRef>,
+            body: FirBlock? = null
+        ): FirConstructor {
+            val constructorCallee = superTypeCallEntry?.calleeExpression?.toFirSourceElement()
+            val constructorSource = this?.toFirSourceElement()
+                ?: owner.toFirPsiSourceElement(FirFakeSourceElementKind.ImplicitConstructor)
+            val firDelegatedCall = buildDelegatedConstructorCall {
+                source = constructorCallee ?: constructorSource.fakeElement(FirFakeSourceElementKind.DelegatingConstructorCall)
+                constructedTypeRef = delegatedSuperTypeRef.copyWithNewSourceKind(FirFakeSourceElementKind.ImplicitTypeRef)
+                isThis = false
+                if (!stubMode) {
+                    superTypeCallEntry?.extractArgumentsTo(this)
+                }
+            }
+
+            // See DescriptorUtils#getDefaultConstructorVisibility in core.descriptors
+            fun defaultVisibility() = when {
+                owner is KtObjectDeclaration || owner.hasModifier(ENUM_KEYWORD) || owner is KtEnumEntry -> Visibilities.Private
+                owner.hasModifier(SEALED_KEYWORD) -> Visibilities.Private
+                else -> Visibilities.Unknown
+            }
+
+            val explicitVisibility = this?.visibility
+            val status = FirDeclarationStatusImpl(explicitVisibility ?: defaultVisibility(), Modality.FINAL).apply {
+                isExpect = this@toFirConstructor?.hasExpectModifier() == true || owner.hasExpectModifier()
+                isActual = this@toFirConstructor?.hasActualModifier() == true
+                isInner = owner.hasModifier(INNER_KEYWORD)
+                isFromSealedClass = owner.hasModifier(SEALED_KEYWORD) && explicitVisibility !== Visibilities.Private
+                isFromEnumClass = owner.hasModifier(ENUM_KEYWORD)
+            }
+            return buildPrimaryConstructor {
+                source = constructorSource
+                session = baseSession
+                origin = FirDeclarationOrigin.Source
+                returnTypeRef = delegatedSelfTypeRef
+                this.status = status
+                symbol = FirConstructorSymbol(callableIdForClassConstructor())
+                delegatedConstructor = firDelegatedCall
+                typeParameters += constructorTypeParametersFromConstructedClass(ownerTypeParameters)
+                this@toFirConstructor?.extractAnnotationsTo(this)
+                this@toFirConstructor?.extractValueParametersTo(this)
+                this.body = body
+            }
+        }
+
+        override fun visitKtFile(file: KtFile, data: Unit): FirElement {
+            context.packageFqName = file.packageFqName
+            return buildFile {
+                source = file.toFirSourceElement()
+                session = baseSession
+                origin = FirDeclarationOrigin.Source
+                name = file.name
+                packageFqName = context.packageFqName
+                for (annotationEntry in file.annotationEntries) {
+                    annotations += annotationEntry.convert<FirAnnotationCall>()
+                }
+                for (importDirective in file.importDirectives) {
+                    imports += buildImport {
+                        source = importDirective.toFirSourceElement()
+                        importedFqName = importDirective.importedFqName
+                        isAllUnder = importDirective.isAllUnder
+                        aliasName = importDirective.aliasName?.let { Name.identifier(it) }
+                    }
+                }
+                for (declaration in file.declarations) {
+                    declarations += declaration.convert<FirDeclaration>()
+                }
+            }
+        }
+
+        private fun KtEnumEntry.toFirEnumEntry(
+            delegatedEnumSelfTypeRef: FirResolvedTypeRef,
+            ownerClassHasDefaultConstructor: Boolean
+        ): FirDeclaration {
+            val ktEnumEntry = this@toFirEnumEntry
+            return buildEnumEntry {
+                source = toFirSourceElement()
+                session = baseSession
+                origin = FirDeclarationOrigin.Source
+                returnTypeRef = delegatedEnumSelfTypeRef
+                name = nameAsSafeName
+                status = FirDeclarationStatusImpl(Visibilities.Public, Modality.FINAL).apply {
+                    isStatic = true
+                    isExpect = containingClassOrObject?.hasExpectModifier() == true
+                }
+                symbol = FirVariableSymbol(callableIdForName(nameAsSafeName))
+                if (ownerClassHasDefaultConstructor && ktEnumEntry.initializerList == null &&
+                    ktEnumEntry.annotationEntries.isEmpty() && ktEnumEntry.body == null
+                ) {
+                    return@buildEnumEntry
+                }
+                extractAnnotationsTo(this)
+                initializer = withChildClassName(nameAsSafeName) {
+                    buildAnonymousObject {
+                        source = toFirSourceElement(FirFakeSourceElementKind.EnumInitializer)
+                        session = baseSession
+                        origin = FirDeclarationOrigin.Source
+                        classKind = ClassKind.ENUM_ENTRY
+                        scopeProvider = this@RawFirBuilder.baseScopeProvider
+                        symbol = FirAnonymousObjectSymbol()
+
+                        extractAnnotationsTo(this)
+                        val delegatedEntrySelfType = buildResolvedTypeRef {
+                            type = ConeClassLikeTypeImpl(this@buildAnonymousObject.symbol.toLookupTag(), emptyArray(), isNullable = false)
+                        }
+                        superTypeRefs += delegatedEnumSelfTypeRef
+                        val superTypeCallEntry = superTypeListEntries.firstIsInstanceOrNull<KtSuperTypeCallEntry>()
+                        val correctedEnumSelfTypeRef = buildResolvedTypeRef {
+                            source = superTypeCallEntry?.calleeExpression?.typeReference?.toFirSourceElement()
+                            type = delegatedEnumSelfTypeRef.type
+                        }
+                        declarations += primaryConstructor.toFirConstructor(
+                            superTypeCallEntry,
+                            correctedEnumSelfTypeRef,
+                            delegatedEntrySelfType,
+                            owner = ktEnumEntry,
+                            typeParameters
+                        )
+                        for (declaration in ktEnumEntry.declarations) {
+                            declarations += declaration.toFirDeclaration(
+                                correctedEnumSelfTypeRef,
+                                delegatedSelfType = delegatedEntrySelfType,
+                                ktEnumEntry,
+                                ownerClassBuilder = this,
+                                ownerTypeParameters = emptyList()
+                            )
+                        }
+                    }
+                }
+            }
+        }
+
+        override fun visitClassOrObject(classOrObject: KtClassOrObject, data: Unit): FirElement {
+            return withChildClassName(
+                classOrObject.nameAsSafeName,
+                classOrObject.isLocal || classOrObject.getStrictParentOfType<KtEnumEntry>() != null
+            ) {
+                val classKind = when (classOrObject) {
+                    is KtObjectDeclaration -> ClassKind.OBJECT
+                    is KtClass -> when {
+                        classOrObject.isInterface() -> ClassKind.INTERFACE
+                        classOrObject.isEnum() -> ClassKind.ENUM_CLASS
+                        classOrObject.isAnnotation() -> ClassKind.ANNOTATION_CLASS
+                        else -> ClassKind.CLASS
+                    }
+                    else -> throw AssertionError("Unexpected class or object: ${classOrObject.text}")
+                }
+                val status = FirDeclarationStatusImpl(
+                    if (classOrObject.isLocal) Visibilities.Local else classOrObject.visibility,
+                    classOrObject.modality,
+                ).apply {
+                    isExpect = classOrObject.hasExpectModifier()
+                    isActual = classOrObject.hasActualModifier()
+                    isInner = classOrObject.hasModifier(INNER_KEYWORD)
+                    isCompanion = (classOrObject as? KtObjectDeclaration)?.isCompanion() == true
+                    isData = classOrObject.hasModifier(DATA_KEYWORD)
+                    isInline = classOrObject.hasModifier(INLINE_KEYWORD)
+                    isFun = classOrObject.hasModifier(FUN_KEYWORD)
+                }
+                withCapturedTypeParameters {
+                    if (!status.isInner) context.capturedTypeParameters = context.capturedTypeParameters.clear()
+
+                    buildRegularClass {
+                        source = classOrObject.toFirSourceElement()
+                        session = baseSession
+                        origin = FirDeclarationOrigin.Source
+                        name = classOrObject.nameAsSafeName
+                        this.status = status
+                        this.classKind = classKind
+                        scopeProvider = baseScopeProvider
+                        symbol = FirRegularClassSymbol(context.currentClassId)
+
+                        classOrObject.extractAnnotationsTo(this)
+                        classOrObject.extractTypeParametersTo(this)
+                        typeParameters += context.capturedTypeParameters.map { buildOuterClassTypeParameterRef { symbol = it } }
+
+                        addCapturedTypeParameters(typeParameters.take(classOrObject.typeParameters.size))
+
+                        val delegatedSelfType = classOrObject.toDelegatedSelfType(this)
+                        val delegatedSuperType = classOrObject.extractSuperTypeListEntriesTo(
+                            this,
+                            delegatedSelfType,
+                            null,
+                            classKind,
+                            typeParameters,
+                            symbol
+                        )
+
+                        val primaryConstructor = classOrObject.primaryConstructor
+                        val firPrimaryConstructor = declarations.firstOrNull {it is FirConstructor} as? FirConstructor
+                        if (primaryConstructor != null && firPrimaryConstructor != null) {
+                            primaryConstructor.valueParameters.zip(
+                                firPrimaryConstructor.valueParameters
+                            ).forEach { (ktParameter, firParameter) ->
+                                if (ktParameter.hasValOrVar()) {
+                                    addDeclaration(ktParameter.toFirProperty(firParameter, classOrObject.hasExpectModifier()))
+                                }
+                            }
+                        }
+
+                        for (declaration in classOrObject.declarations) {
+                            addDeclaration(
+                                declaration.toFirDeclaration(
+                                    delegatedSuperType,
+                                    delegatedSelfType,
+                                    classOrObject,
+                                    this,
+                                    typeParameters
+                                ),
+                            )
+                        }
+
+                        if (classOrObject.hasModifier(DATA_KEYWORD) && firPrimaryConstructor != null) {
+                            val zippedParameters = classOrObject.primaryConstructorParameters.zip(
+                                declarations.filterIsInstance<FirProperty>(),
+                            )
+                            DataClassMembersGenerator(
+                                baseSession,
+                                classOrObject,
+                                this,
+                                zippedParameters,
+                                context.packageFqName,
+                                context.className,
+                                createClassTypeRefWithSourceKind = { firPrimaryConstructor.returnTypeRef.copyWithNewSourceKind(it) },
+                                createParameterTypeRefWithSourceKind = { property, newKind ->
+                                    // just making a shallow copy isn't enough type ref may be a function type ref
+                                    // and contain value parameters inside
+                                    withDefaultSourceElementKind(newKind) {
+                                        (property.returnTypeRef.psi as KtTypeReference).toFirOrImplicitType()
+                                    }
+                                },
+                            ).generate()
+                        }
+
+                        if (classOrObject.hasModifier(ENUM_KEYWORD)) {
+                            generateValuesFunction(
+                                baseSession, context.packageFqName, context.className, classOrObject.hasExpectModifier()
+                            )
+                            generateValueOfFunction(
+                                baseSession, context.packageFqName, context.className, classOrObject.hasExpectModifier()
+                            )
+                        }
+                    }
+                }
+            }
+        }
+
+        override fun visitObjectLiteralExpression(expression: KtObjectLiteralExpression, data: Unit): FirElement {
+            val objectDeclaration = expression.objectDeclaration
+            return withChildClassName(ANONYMOUS_OBJECT_NAME) {
+                buildAnonymousObject {
+                    source = expression.toFirSourceElement()
+                    session = baseSession
+                    origin = FirDeclarationOrigin.Source
+                    classKind = ClassKind.OBJECT
+                    scopeProvider = baseScopeProvider
+                    symbol = FirAnonymousObjectSymbol()
+                    typeParameters += context.capturedTypeParameters.map { buildOuterClassTypeParameterRef { symbol = it } }
+                    val delegatedSelfType = objectDeclaration.toDelegatedSelfType(this)
+                    objectDeclaration.extractAnnotationsTo(this)
+                    val delegatedSuperType = objectDeclaration.extractSuperTypeListEntriesTo(
+                        this,
+                        delegatedSelfType,
+                        null,
+                        ClassKind.CLASS,
+                        containerTypeParameters = emptyList(),
+                        symbol
+                    )
+                    typeRef = delegatedSelfType
+
+
+                    for (declaration in objectDeclaration.declarations) {
+                        declarations += declaration.toFirDeclaration(
+                            delegatedSuperType,
+                            delegatedSelfType,
+                            owner = objectDeclaration,
+                            ownerClassBuilder = this,
+                            ownerTypeParameters = emptyList()
+                        )
+                    }
+                }
+            }
+        }
+
+        override fun visitTypeAlias(typeAlias: KtTypeAlias, data: Unit): FirElement {
+            return withChildClassName(typeAlias.nameAsSafeName) {
+                buildTypeAlias {
+                    source = typeAlias.toFirSourceElement()
+                    session = baseSession
+                    origin = FirDeclarationOrigin.Source
+                    name = typeAlias.nameAsSafeName
+                    status = FirDeclarationStatusImpl(typeAlias.visibility, Modality.FINAL).apply {
+                        isExpect = typeAlias.hasExpectModifier()
+                        isActual = typeAlias.hasActualModifier()
+                    }
+                    symbol = FirTypeAliasSymbol(context.currentClassId)
+                    expandedTypeRef = typeAlias.getTypeReference().toFirOrErrorType()
+                    typeAlias.extractAnnotationsTo(this)
+                    typeAlias.extractTypeParametersTo(this)
+                }
+            }
+        }
+
+        override fun visitNamedFunction(function: KtNamedFunction, data: Unit): FirElement {
+            val typeReference = function.typeReference
+            val returnType = if (function.hasBlockBody()) {
+                typeReference.toFirOrUnitType()
+            } else {
+                typeReference.toFirOrImplicitType()
+            }
+            val receiverType = function.receiverTypeReference.convertSafe<FirTypeRef>()
+
+            val labelName: String?
+            val functionIsAnonymousFunction = function.name == null && !function.parent.let { it is KtFile || it is KtClassBody }
+            val functionBuilder = if (functionIsAnonymousFunction) {
+                FirAnonymousFunctionBuilder().apply {
+                    receiverTypeRef = receiverType
+                    symbol = FirAnonymousFunctionSymbol()
+                    isLambda = false
+                    labelName = function.getLabelName()
+                }
+            } else {
+                FirSimpleFunctionBuilder().apply {
+                    receiverTypeRef = receiverType
+                    name = function.nameAsSafeName
+                    labelName = runIf(!name.isSpecial) { name.identifier }
+                    symbol = FirNamedFunctionSymbol(callableIdForName(function.nameAsSafeName, function.isLocal))
+                    status = FirDeclarationStatusImpl(
+                        if (function.isLocal) Visibilities.Local else function.visibility,
+                        function.modality,
+                    ).apply {
+                        isExpect = function.hasExpectModifier() || function.containingClassOrObject?.hasExpectModifier() == true
+                        isActual = function.hasActualModifier()
+                        isOverride = function.hasModifier(OVERRIDE_KEYWORD)
+                        isOperator = function.hasModifier(OPERATOR_KEYWORD)
+                        isInfix = function.hasModifier(INFIX_KEYWORD)
+                        isInline = function.hasModifier(INLINE_KEYWORD)
+                        isTailRec = function.hasModifier(TAILREC_KEYWORD)
+                        isExternal = function.hasModifier(EXTERNAL_KEYWORD)
+                        isSuspend = function.hasModifier(SUSPEND_KEYWORD)
+                    }
+                }
+            }
+
+            val target = FirFunctionTarget(labelName, isLambda = false)
+            return functionBuilder.apply {
+                source = function.toFirSourceElement()
+                session = baseSession
+                origin = FirDeclarationOrigin.Source
+                returnTypeRef = returnType
+
+                context.firFunctionTargets += target
+                function.extractAnnotationsTo(this)
+                if (this is FirSimpleFunctionBuilder) {
+                    function.extractTypeParametersTo(this)
+                }
+                for (valueParameter in function.valueParameters) {
+                    valueParameters += valueParameter.convert<FirValueParameter>()
+                }
+                withCapturedTypeParameters {
+                    if (this is FirSimpleFunctionBuilder) addCapturedTypeParameters(this.typeParameters)
+                    val outerContractDescription = function.obtainContractDescription()
+                    val bodyWithContractDescription = function.buildFirBody()
+                    this.body = bodyWithContractDescription.first
+                    val contractDescription = outerContractDescription ?: bodyWithContractDescription.second
+                    contractDescription?.let {
+                        // TODO: add error reporting for contracts on lambdas
+                        if (this is FirSimpleFunctionBuilder) {
+                            this.contractDescription = it
+                        }
+                    }
+                }
+                context.firFunctionTargets.removeLast()
+            }.build().also {
+                target.bind(it)
+            }
+        }
+
+        private fun KtDeclarationWithBody.obtainContractDescription(): FirContractDescription? {
+            return when(val description = contractDescription) {
+                null -> null
+                else -> buildRawContractDescription {
+                    source = description.toFirSourceElement()
+                    description.extractRawEffects(rawEffects)
+                }
+            }
+        }
+
+        private fun KtContractEffectList.extractRawEffects(destination: MutableList<FirExpression>) {
+            getExpressions()
+                .mapTo(destination) { it.accept(this@Visitor, Unit) as FirExpression }
+        }
+
+        override fun visitLambdaExpression(expression: KtLambdaExpression, data: Unit): FirElement {
+            val literal = expression.functionLiteral
+            val literalSource = literal.toFirSourceElement()
+            val implicitTypeRefSource = literal.toFirSourceElement(FirFakeSourceElementKind.ImplicitTypeRef)
+            val returnType = buildImplicitTypeRef {
+                source = implicitTypeRefSource
+            }
+            val receiverType = buildImplicitTypeRef {
+                source = implicitTypeRefSource
+            }
+
+            val target: FirFunctionTarget
+            return buildAnonymousFunction {
+                source = literalSource
+                session = baseSession
+                origin = FirDeclarationOrigin.Source
+                returnTypeRef = returnType
+                receiverTypeRef = receiverType
+                symbol = FirAnonymousFunctionSymbol()
+                isLambda = true
+
+                var destructuringBlock: FirExpression? = null
+                for (valueParameter in literal.valueParameters) {
+                    val multiDeclaration = valueParameter.destructuringDeclaration
+                    valueParameters += if (multiDeclaration != null) {
+                        val name = Name.special("<destruct>")
+                        val multiParameter = buildValueParameter {
+                            source = valueParameter.toFirSourceElement()
+                            session = baseSession
+                            origin = FirDeclarationOrigin.Source
+                            returnTypeRef = buildImplicitTypeRef {
+                                source = multiDeclaration.toFirSourceElement(FirFakeSourceElementKind.ImplicitTypeRef)
+                            }
+                            this.name = name
+                            symbol = FirVariableSymbol(name)
+                            isCrossinline = false
+                            isNoinline = false
+                            isVararg = false
+                        }
+                        destructuringBlock = generateDestructuringBlock(
+                            baseSession,
+                            multiDeclaration,
+                            multiParameter,
+                            tmpVariable = false,
+                            extractAnnotationsTo = { extractAnnotationsTo(it) },
+                        ) { toFirOrImplicitType() }
+                        multiParameter
+                    } else {
+                        val typeRef = buildImplicitTypeRef {
+                            source = implicitTypeRefSource
+                        }
+                        valueParameter.toFirValueParameter(typeRef)
+                    }
+                }
+                val expressionSource = expression.toFirSourceElement()
+                label = context.firLabels.pop() ?: context.calleeNamesForLambda.lastOrNull()?.let {
+                    buildLabel {
+                        source = expressionSource.fakeElement(FirFakeSourceElementKind.GeneratedLambdaLabel)
+                        name = it.asString()
+                    }
+                }
+                target = FirFunctionTarget(label?.name, isLambda = true).also {
+                    context.firFunctionTargets += it
+                }
+                val ktBody = literal.bodyExpression
+                body = if (ktBody == null) {
+                    val errorExpression = buildErrorExpression(source, ConeSimpleDiagnostic("Lambda has no body", DiagnosticKind.Syntax))
+                    FirSingleExpressionBlock(errorExpression.toReturn())
+                } else {
+                    configureBlockWithoutBuilding(ktBody).apply {
+                        if (statements.isEmpty()) {
+                            statements.add(
+                                buildReturnExpression {
+                                    source = expressionSource.fakeElement(FirFakeSourceElementKind.ImplicitReturn)
+                                    this.target = target
+                                    result = buildUnitExpression {
+                                        source = expressionSource.fakeElement(FirFakeSourceElementKind.ImplicitUnit)
+                                    }
+                                }
+                            )
+                        }
+                        if (destructuringBlock is FirBlock) {
+                            for ((index, statement) in destructuringBlock.statements.withIndex()) {
+                                statements.add(index, statement)
+                            }
+                        }
+                    }.build()
+                }
+                context.firFunctionTargets.removeLast()
+            }.also {
+                target.bind(it)
+            }
+        }
+
+        private fun KtSecondaryConstructor.toFirConstructor(
+            delegatedSuperTypeRef: FirTypeRef,
+            delegatedSelfTypeRef: FirTypeRef,
+            owner: KtClassOrObject,
+            ownerTypeParameters: List<FirTypeParameterRef>
+        ): FirConstructor {
+            val target = FirFunctionTarget(labelName = null, isLambda = false)
+            return buildConstructor {
+                source = this@toFirConstructor.toFirSourceElement()
+                session = baseSession
+                origin = FirDeclarationOrigin.Source
+                returnTypeRef = delegatedSelfTypeRef
+                val explicitVisibility = visibility
+                status = FirDeclarationStatusImpl(explicitVisibility, Modality.FINAL).apply {
+                    isExpect = hasExpectModifier() || owner.hasExpectModifier()
+                    isActual = hasActualModifier()
+                    isInner = owner.hasModifier(INNER_KEYWORD)
+                    isFromSealedClass = owner.hasModifier(SEALED_KEYWORD) && explicitVisibility !== Visibilities.Private
+                    isFromEnumClass = owner.hasModifier(ENUM_KEYWORD)
+                }
+                symbol = FirConstructorSymbol(callableIdForClassConstructor())
+                delegatedConstructor = getDelegationCall().convert(
+                    delegatedSuperTypeRef,
+                    delegatedSelfTypeRef,
+                )
+                this@RawFirBuilder.context.firFunctionTargets += target
+                extractAnnotationsTo(this)
+                typeParameters += constructorTypeParametersFromConstructedClass(ownerTypeParameters)
+                extractValueParametersTo(this)
+                val (body, _) = buildFirBody()
+                this.body = body
+                this@RawFirBuilder.context.firFunctionTargets.removeLast()
+            }.also {
+                target.bind(it)
+            }
+        }
+
+        private fun KtConstructorDelegationCall.convert(
+            delegatedSuperTypeRef: FirTypeRef,
+            delegatedSelfTypeRef: FirTypeRef,
+        ): FirDelegatedConstructorCall {
+            val isThis = isCallToThis //|| (isImplicit && hasPrimaryConstructor)
+            val source = if (isImplicit) {
+                this.toFirSourceElement(FirFakeSourceElementKind.ImplicitConstructor)
+            } else {
+                this.toFirSourceElement()
+            }
+            val delegatedType = when {
+                isThis -> delegatedSelfTypeRef
+                else -> delegatedSuperTypeRef
+            }
+            return buildDelegatedConstructorCall {
+                this.source = source
+                constructedTypeRef = delegatedType.copyWithNewSourceKind(FirFakeSourceElementKind.ImplicitTypeRef)
+                this.isThis = isThis
+                if (!stubMode) {
+                    extractArgumentsTo(this)
+                }
+            }
+        }
+
+        private fun KtProperty.toFirProperty(ownerClassBuilder: FirClassBuilder?): FirProperty {
+            val propertyType = typeReference.toFirOrImplicitType()
+            val propertyName = nameAsSafeName
+            val isVar = isVar
+            val propertyInitializer = if (hasInitializer()) {
+                { initializer }.toFirExpression("Should have initializer")
+            } else null
+            val delegateExpression by lazy { delegate?.expression }
+            val propertySource = toFirSourceElement()
+
+            return buildProperty {
+                source = propertySource
+                session = baseSession
+                origin = FirDeclarationOrigin.Source
+                returnTypeRef = propertyType
+                name = propertyName
+                this.isVar = isVar
+
+                initializer = propertyInitializer
+
+                if (this@toFirProperty.isLocal) {
+                    isLocal = true
+                    symbol = FirPropertySymbol(propertyName)
+                    val delegateBuilder = delegateExpression?.let {
+                        FirWrappedDelegateExpressionBuilder().apply {
+                            source = it.toFirSourceElement(FirFakeSourceElementKind.WrappedDelegate)
+                            expression = it.toFirExpression("Incorrect delegate expression")
+                        }
+                    }
+
+                    status = FirDeclarationStatusImpl(Visibilities.Local, Modality.FINAL).apply {
+                        isLateInit = hasModifier(LATEINIT_KEYWORD)
+                    }
+
+                    val receiver = delegateExpression?.toFirExpression("Incorrect delegate expression")
+                    generateAccessorsByDelegate(delegateBuilder, null, baseSession, isExtension = false, stubMode, receiver)
+                } else {
+                    isLocal = false
+                    receiverTypeRef = receiverTypeReference.convertSafe()
+                    symbol = FirPropertySymbol(callableIdForName(propertyName))
+                    extractTypeParametersTo(this)
+                    withCapturedTypeParameters {
+                        addCapturedTypeParameters(this.typeParameters)
+                        val delegateBuilder = if (hasDelegate()) {
+                            FirWrappedDelegateExpressionBuilder().apply {
+                                source =
+                                    if (stubMode) null else delegateExpression?.toFirSourceElement(FirFakeSourceElementKind.WrappedDelegate)
+                                expression = { delegateExpression }.toFirExpression("Should have delegate")
+                            }
+                        } else null
+
+                        getter = this@toFirProperty.getter.toFirPropertyAccessor(this@toFirProperty, propertyType, isGetter = true)
+                        setter = if (isVar) {
+                            this@toFirProperty.setter.toFirPropertyAccessor(this@toFirProperty, propertyType, isGetter = false)
+                        } else null
+
+                        // Upward propagation of `inline` and `external` modifiers (from accessors to property)
+                        // Note that, depending on `var` or `val`, checking setter's modifiers should be careful: for `val`, setter doesn't
+                        // exist (null); for `var`, the retrieval of the specific modifier is supposed to be `true`
+                        status = FirDeclarationStatusImpl(visibility, modality).apply {
+                            isExpect = hasExpectModifier() || containingClassOrObject?.hasExpectModifier() == true
+                            isActual = hasActualModifier()
+                            isOverride = hasModifier(OVERRIDE_KEYWORD)
+                            isConst = hasModifier(CONST_KEYWORD)
+                            isLateInit = hasModifier(LATEINIT_KEYWORD)
+                            isInline = hasModifier(INLINE_KEYWORD) || (getter!!.isInline && setter?.isInline != false)
+                            isExternal = hasModifier(EXTERNAL_KEYWORD) || (getter!!.isExternal && setter?.isExternal != false)
+                        }
+
+                        val receiver = delegateExpression?.toFirExpression("Should have delegate")
+                        generateAccessorsByDelegate(
+                            delegateBuilder,
+                            ownerClassBuilder,
+                            baseSession,
+                            isExtension = receiverTypeReference != null,
+                            stubMode,
+                            receiver
+                        )
+                    }
+                }
+                extractAnnotationsTo(this)
+            }
+        }
+
+        override fun visitAnonymousInitializer(initializer: KtAnonymousInitializer, data: Unit): FirElement {
+            return buildAnonymousInitializer {
+                source = initializer.toFirSourceElement()
+                session = baseSession
+                origin = FirDeclarationOrigin.Source
+                body = if (stubMode) buildEmptyExpressionBlock() else initializer.body.toFirBlock()
+            }
+        }
+
+        override fun visitProperty(property: KtProperty, data: Unit): FirElement {
+            return property.toFirProperty(ownerClassBuilder = null)
+        }
+
+        override fun visitTypeReference(typeReference: KtTypeReference, data: Unit): FirElement {
+            val typeElement = typeReference.typeElement
+            val source = typeReference.toFirSourceElement()
+            val isNullable = typeElement is KtNullableType
+
+            fun KtTypeElement?.unwrapNullable(): KtTypeElement? =
+                if (this is KtNullableType) this.innerType.unwrapNullable() else this
+
+            val firTypeBuilder = when (val unwrappedElement = typeElement.unwrapNullable()) {
+                is KtDynamicType -> FirDynamicTypeRefBuilder().apply {
+                    this.source = source
+                    isMarkedNullable = isNullable
+                }
+                is KtUserType -> {
+                    var referenceExpression = unwrappedElement.referenceExpression
+                    if (referenceExpression != null) {
+                        FirUserTypeRefBuilder().apply {
+                            this.source = source
+                            isMarkedNullable = isNullable
+                            var ktQualifier: KtUserType? = unwrappedElement
+
+                            do {
+                                val firQualifier = FirQualifierPartImpl(
+                                    referenceExpression!!.getReferencedNameAsName(),
+                                    FirTypeArgumentListImpl(source).apply {
+                                        for (typeArgument in ktQualifier!!.typeArguments) {
+                                            typeArguments += typeArgument.convert<FirTypeProjection>()
+                                        }
+                                    }
+                                )
+                                qualifier.add(firQualifier)
+
+                                ktQualifier = ktQualifier!!.qualifier
+                                referenceExpression = ktQualifier?.referenceExpression
+                            } while (referenceExpression != null)
+
+                            qualifier.reverse()
+                        }
+                    } else {
+                        FirErrorTypeRefBuilder().apply {
+                            this.source = source
+                            diagnostic = ConeSimpleDiagnostic("Incomplete user type", DiagnosticKind.Syntax)
+                        }
+                    }
+                }
+                is KtFunctionType -> {
+                    FirFunctionTypeRefBuilder().apply {
+                        this.source = source
+                        isMarkedNullable = isNullable
+                        isSuspend = typeReference.hasModifier(SUSPEND_KEYWORD)
+                        receiverTypeRef = unwrappedElement.receiverTypeReference.convertSafe()
+                        // TODO: probably implicit type should not be here
+                        returnTypeRef = unwrappedElement.returnTypeReference.toFirOrErrorType()
+                        for (valueParameter in unwrappedElement.parameters) {
+                            valueParameters += valueParameter.convert<FirValueParameter>()
+                        }
+                        if (receiverTypeRef != null) {
+                            annotations += extensionFunctionAnnotation
+                        }
+                    }
+                }
+                null -> FirErrorTypeRefBuilder().apply {
+                    this.source = source
+                    diagnostic = ConeSimpleDiagnostic("Unwrapped type is null", DiagnosticKind.Syntax)
+                }
+                else -> throw AssertionError("Unexpected type element: ${unwrappedElement.text}")
+            }
+
+            for (annotationEntry in typeReference.annotationEntries) {
+                firTypeBuilder.annotations += annotationEntry.convert<FirAnnotationCall>()
+            }
+            return firTypeBuilder.build()
+        }
+
+        override fun visitAnnotationEntry(annotationEntry: KtAnnotationEntry, data: Unit): FirElement {
+            return buildAnnotationCall {
+                source = annotationEntry.toFirSourceElement()
+                useSiteTarget = annotationEntry.useSiteTarget?.getAnnotationUseSiteTarget()
+                annotationTypeRef = annotationEntry.typeReference.toFirOrErrorType()
+                annotationEntry.extractArgumentsTo(this)
+                val name = (annotationTypeRef as? FirUserTypeRef)?.qualifier?.last()?.name ?: Name.special("<no-annotation-name>")
+                calleeReference = buildSimpleNamedReference {
+                    source = this@buildAnnotationCall.source
+                    this.name = name
+                }
+            }
+        }
+
+        override fun visitTypeParameter(parameter: KtTypeParameter, data: Unit): FirElement {
+            val parameterName = parameter.nameAsSafeName
+            return buildTypeParameter {
+                source = parameter.toFirSourceElement()
+                session = baseSession
+                origin = FirDeclarationOrigin.Source
+                name = parameterName
+                symbol = FirTypeParameterSymbol()
+                variance = parameter.variance
+                isReified = parameter.hasModifier(REIFIED_KEYWORD)
+                parameter.extractAnnotationsTo(this)
+                val extendsBound = parameter.extendsBound
+                if (extendsBound != null) {
+                    bounds += extendsBound.convert<FirTypeRef>()
+                }
+                val owner = parameter.getStrictParentOfType<KtTypeParameterListOwner>() ?: return@buildTypeParameter
+                for (typeConstraint in owner.typeConstraints) {
+                    val subjectName = typeConstraint.subjectTypeParameterName?.getReferencedNameAsName()
+                    if (subjectName == parameterName) {
+                        bounds += typeConstraint.boundTypeReference.toFirOrErrorType()
+                    }
+                }
+                addDefaultBoundIfNecessary()
+            }
+        }
+
+        override fun visitTypeProjection(typeProjection: KtTypeProjection, data: Unit): FirElement {
+            val projectionKind = typeProjection.projectionKind
+            val projectionSource = typeProjection.toFirSourceElement()
+            if (projectionKind == KtProjectionKind.STAR) {
+                return buildStarProjection {
+                    source = projectionSource
+                }
+            }
+            if (projectionKind == KtProjectionKind.NONE && !stubMode && typeProjection.text == "_") {
+                return FirTypePlaceholderProjection
+            }
+            val typeReference = typeProjection.typeReference
+            val firType = typeReference.toFirOrErrorType()
+            return buildTypeProjectionWithVariance {
+                source = projectionSource
+                typeRef = firType
+                variance = when (projectionKind) {
+                    KtProjectionKind.IN -> Variance.IN_VARIANCE
+                    KtProjectionKind.OUT -> Variance.OUT_VARIANCE
+                    KtProjectionKind.NONE -> Variance.INVARIANT
+                    KtProjectionKind.STAR -> throw AssertionError("* should not be here")
+                }
+            }
+        }
+
+        override fun visitParameter(parameter: KtParameter, data: Unit): FirElement =
+            parameter.toFirValueParameter()
+
+        override fun visitBlockExpression(expression: KtBlockExpression, data: Unit): FirElement {
+            return configureBlockWithoutBuilding(expression).build()
+        }
+
+        private fun configureBlockWithoutBuilding(expression: KtBlockExpression): FirBlockBuilder {
+            return FirBlockBuilder().apply {
+                source = expression.toFirSourceElement()
+                for (statement in expression.statements) {
+                    val firStatement = statement.toFirStatement("Statement expected: ${statement.text}")
+                    if (firStatement !is FirBlock || firStatement.annotations.isNotEmpty()) {
+                        statements += firStatement
+                    } else {
+                        statements += firStatement.statements
+                    }
+                }
+            }
+        }
+
+        override fun visitSimpleNameExpression(expression: KtSimpleNameExpression, data: Unit): FirElement {
+            return generateAccessExpression(expression.toFirSourceElement(), expression.getReferencedNameAsName())
+        }
+
+        override fun visitConstantExpression(expression: KtConstantExpression, data: Unit): FirElement =
+            generateConstantExpressionByLiteral(expression)
+
+        override fun visitStringTemplateExpression(expression: KtStringTemplateExpression, data: Unit): FirElement {
+            return expression.entries.toInterpolatingCall(expression) {
+                (this as KtStringTemplateEntryWithExpression).expression.toFirExpression(it)
+            }
+        }
+
+        override fun visitReturnExpression(expression: KtReturnExpression, data: Unit): FirElement {
+            val source = expression.toFirSourceElement(FirFakeSourceElementKind.ImplicitUnit)
+            val result = expression.returnedExpression?.toFirExpression("Incorrect return expression")
+                ?: buildUnitExpression { this.source = source }
+            return result.toReturn(source, expression.getTargetLabel()?.getReferencedName())
+        }
+
+        override fun visitTryExpression(expression: KtTryExpression, data: Unit): FirElement {
+            return buildTryExpression {
+                source = expression.toFirSourceElement()
+                tryBlock = expression.tryBlock.toFirBlock()
+                finallyBlock = expression.finallyBlock?.finalExpression?.toFirBlock()
+                for (clause in expression.catchClauses) {
+                    val parameter = clause.catchParameter?.toFirValueParameter() ?: continue
+                    catches += buildCatch {
+                        source = clause.toFirSourceElement()
+                        this.parameter = parameter
+                        block = clause.catchBody.toFirBlock()
+                    }
+                }
+            }
+        }
+
+        override fun visitIfExpression(expression: KtIfExpression, data: Unit): FirElement {
+            return buildWhenExpression {
+                source = expression.toFirSourceElement()
+                val ktCondition = expression.condition
+                branches += buildWhenBranch {
+                    source = ktCondition?.toFirSourceElement(FirFakeSourceElementKind.WhenCondition)
+                    condition = ktCondition.toFirExpression("If statement should have condition")
+                    result = expression.then.toFirBlock()
+                }
+                if (expression.elseKeyword != null) {
+                    branches += buildWhenBranch {
+                        condition = buildElseIfTrueCondition()
+                        result = expression.`else`.toFirBlock()
+                    }
+                }
+            }
+        }
+
+        override fun visitWhenExpression(expression: KtWhenExpression, data: Unit): FirElement {
+            val ktSubjectExpression = expression.subjectExpression
+            val subjectExpression = when (ktSubjectExpression) {
+                is KtVariableDeclaration -> ktSubjectExpression.initializer
+                else -> ktSubjectExpression
+            }?.toFirExpression("Incorrect when subject expression: ${ktSubjectExpression?.text}")
+            val subjectVariable = when (ktSubjectExpression) {
+                is KtVariableDeclaration -> {
+                    val name = ktSubjectExpression.nameAsSafeName
+                    buildProperty {
+                        source = ktSubjectExpression.toFirSourceElement()
+                        session = baseSession
+                        origin = FirDeclarationOrigin.Source
+                        returnTypeRef = ktSubjectExpression.typeReference.toFirOrImplicitType()
+                        receiverTypeRef = null
+                        this.name = name
+                        initializer = subjectExpression
+                        delegate = null
+                        isVar = false
+                        symbol = FirPropertySymbol(name)
+                        isLocal = true
+                        status = FirDeclarationStatusImpl(Visibilities.Local, Modality.FINAL)
+                    }
+                }
+                else -> null
+            }
+            val hasSubject = subjectExpression != null
+
+            @OptIn(FirContractViolation::class)
+            val ref = FirExpressionRef<FirWhenExpression>()
+            return buildWhenExpression {
+                source = expression.toFirSourceElement()
+                this.subject = subjectExpression
+                this.subjectVariable = subjectVariable
+
+                for (entry in expression.entries) {
+                    val entrySource = entry.toFirSourceElement()
+                    val branchBody = entry.expression.toFirBlock()
+                    branches += if (!entry.isElse) {
+                        if (hasSubject) {
+                            buildWhenBranch {
+                                source = entrySource
+                                condition = entry.conditions.toFirWhenCondition(
+                                    ref,
+                                    { toFirExpression(it) },
+                                    { toFirOrErrorType() },
+                                )
+                                result = branchBody
+                            }
+                        } else {
+                            val ktCondition = entry.conditions.first() as? KtWhenConditionWithExpression
+                            buildWhenBranch {
+                                source = entrySource
+                                condition = ktCondition?.expression.toFirExpression("No expression in condition with expression")
+                                result = branchBody
+                            }
+                        }
+                    } else {
+                        buildWhenBranch {
+                            source = entrySource
+                            condition = buildElseIfTrueCondition()
+                            result = branchBody
+                        }
+                    }
+                }
+            }.also {
+                if (hasSubject) {
+                    ref.bind(it)
+                }
+            }
+        }
+
+        override fun visitDoWhileExpression(expression: KtDoWhileExpression, data: Unit): FirElement {
+            return FirDoWhileLoopBuilder().apply {
+                source = expression.toFirSourceElement()
+                condition = expression.condition.toFirExpression("No condition in do-while loop")
+            }.configure { expression.body.toFirBlock() }
+        }
+
+        override fun visitWhileExpression(expression: KtWhileExpression, data: Unit): FirElement {
+            return FirWhileLoopBuilder().apply {
+                source = expression.toFirSourceElement()
+                condition = expression.condition.toFirExpression("No condition in while loop")
+            }.configure { expression.body.toFirBlock() }
+        }
+
+        override fun visitForExpression(expression: KtForExpression, data: Unit?): FirElement {
+            val rangeExpression = expression.loopRange.toFirExpression("No range in for loop")
+            val ktParameter = expression.loopParameter
+            val fakeSource = expression.toFirPsiSourceElement(FirFakeSourceElementKind.DesugaredForLoop)
+            return buildBlock {
+                source = fakeSource
+                val rangeSource = expression.loopRange?.toFirSourceElement(FirFakeSourceElementKind.DesugaredForLoop)
+                val iteratorVal = generateTemporaryVariable(
+                    baseSession, rangeSource, Name.special("<iterator>"),
+                    buildFunctionCall {
+                        source = fakeSource
+                        calleeReference = buildSimpleNamedReference {
+                            source = fakeSource
+                            name = Name.identifier("iterator")
+                        }
+                        explicitReceiver = rangeExpression
+                    },
+                )
+                statements += iteratorVal
+                statements += FirWhileLoopBuilder().apply {
+                    source = expression.toFirSourceElement()
+                    condition = buildFunctionCall {
+                        source = fakeSource
+                        calleeReference = buildSimpleNamedReference {
+                            source = fakeSource
+                            name = Name.identifier("hasNext")
+                        }
+                        explicitReceiver = generateResolvedAccessExpression(fakeSource, iteratorVal)
+                    }
+                }.configure {
+                    // NB: just body.toFirBlock() isn't acceptable here because we need to add some statements
+                    val blockBuilder = when (val body = expression.body) {
+                        is KtBlockExpression -> configureBlockWithoutBuilding(body)
+                        null -> FirBlockBuilder()
+                        else -> FirBlockBuilder().apply {
+                            source = body.toFirSourceElement(FirFakeSourceElementKind.DesugaredForLoop)
+                            statements += body.toFirStatement()
+                        }
+                    }
+                    if (ktParameter != null) {
+                        val multiDeclaration = ktParameter.destructuringDeclaration
+                        val firLoopParameter = generateTemporaryVariable(
+                            session = baseSession, source = expression.loopParameter?.toFirSourceElement(),
+                            name = if (multiDeclaration != null) Name.special("<destruct>") else ktParameter.nameAsSafeName,
+                            initializer = buildFunctionCall {
+                                source = fakeSource
+                                calleeReference = buildSimpleNamedReference {
+                                    source = fakeSource
+                                    name = Name.identifier("next")
+                                }
+                                explicitReceiver = generateResolvedAccessExpression(fakeSource, iteratorVal)
+                            },
+                            typeRef = ktParameter.typeReference.toFirOrImplicitType(),
+                        )
+                        if (multiDeclaration != null) {
+                            val destructuringBlock = generateDestructuringBlock(
+                                session = baseSession,
+                                multiDeclaration = multiDeclaration,
+                                container = firLoopParameter,
+                                tmpVariable = true,
+                                extractAnnotationsTo = { extractAnnotationsTo(it) },
+                            ) { toFirOrImplicitType() }
+                            if (destructuringBlock is FirBlock) {
+                                for ((index, statement) in destructuringBlock.statements.withIndex()) {
+                                    blockBuilder.statements.add(index, statement)
+                                }
+                            }
+                        } else {
+                            blockBuilder.statements.add(0, firLoopParameter)
+                        }
+                    }
+                    blockBuilder.build()
+                }
+            }
+        }
+
+        override fun visitBreakExpression(expression: KtBreakExpression, data: Unit): FirElement {
+            return FirBreakExpressionBuilder().apply {
+                source = expression.toFirSourceElement()
+            }.bindLabel(expression).build()
+        }
+
+        override fun visitContinueExpression(expression: KtContinueExpression, data: Unit): FirElement {
+            return FirContinueExpressionBuilder().apply {
+                source = expression.toFirSourceElement()
+            }.bindLabel(expression).build()
+        }
+
+        override fun visitBinaryExpression(expression: KtBinaryExpression, data: Unit): FirElement {
+            val operationToken = expression.operationToken
+
+            if (operationToken == IDENTIFIER) {
+                context.calleeNamesForLambda += expression.operationReference.getReferencedNameAsName()
+            }
+
+            val leftArgument = expression.left.toFirExpression("No left operand")
+            val rightArgument = expression.right.toFirExpression("No right operand")
+
+            if (operationToken == IDENTIFIER) {
+                // No need for the callee name since arguments are already generated
+                context.calleeNamesForLambda.removeLast()
+            }
+
+            val source = expression.toFirSourceElement()
+
+            when (operationToken) {
+                ELVIS ->
+                    return leftArgument.generateNotNullOrOther(rightArgument, source)
+                ANDAND, OROR ->
+                    return leftArgument.generateLazyLogicalOperation(rightArgument, operationToken == ANDAND, source)
+                in OperatorConventions.IN_OPERATIONS ->
+                    return rightArgument.generateContainsOperation(
+                        leftArgument, operationToken == NOT_IN, source, expression.operationReference.toFirSourceElement(),
+                    )
+                in OperatorConventions.COMPARISON_OPERATIONS ->
+                    return leftArgument.generateComparisonExpression(
+                        rightArgument, operationToken, source, expression.operationReference.toFirSourceElement(),
+                    )
+            }
+            val conventionCallName = operationToken.toBinaryName()
+            return if (conventionCallName != null || operationToken == IDENTIFIER) {
+                buildFunctionCall {
+                    this.source = source
+                    calleeReference = buildSimpleNamedReference {
+                        this.source = expression.operationReference.toFirSourceElement()
+                        name = conventionCallName ?: expression.operationReference.getReferencedNameAsName()
+                    }
+                    explicitReceiver = leftArgument
+                    argumentList = buildUnaryArgumentList(rightArgument)
+                }
+            } else {
+                val firOperation = operationToken.toFirOperation()
+                if (firOperation in FirOperation.ASSIGNMENTS) {
+                    return expression.left.generateAssignment(source, expression.right, rightArgument, firOperation) {
+                        (this as KtExpression).toFirExpression("Incorrect expression in assignment: ${expression.text}")
+                    }
+                } else {
+                    buildEqualityOperatorCall {
+                        this.source = source
+                        operation = firOperation
+                        argumentList = buildBinaryArgumentList(leftArgument, rightArgument)
+                    }
+                }
+            }
+        }
+
+        override fun visitBinaryWithTypeRHSExpression(expression: KtBinaryExpressionWithTypeRHS, data: Unit): FirElement {
+            return buildTypeOperatorCall {
+                source = expression.toFirSourceElement()
+                operation = expression.operationReference.getReferencedNameElementType().toFirOperation()
+                conversionTypeRef = expression.right.toFirOrErrorType()
+                argumentList = buildUnaryArgumentList(expression.left.toFirExpression("No left operand"))
+            }
+        }
+
+        override fun visitIsExpression(expression: KtIsExpression, data: Unit): FirElement {
+            return buildTypeOperatorCall {
+                source = expression.toFirSourceElement()
+                operation = if (expression.isNegated) FirOperation.NOT_IS else FirOperation.IS
+                conversionTypeRef = expression.typeReference.toFirOrErrorType()
+                argumentList = buildUnaryArgumentList(expression.leftHandSide.toFirExpression("No left operand"))
+            }
+        }
+
+        override fun visitUnaryExpression(expression: KtUnaryExpression, data: Unit): FirElement {
+            val operationToken = expression.operationToken
+            val argument = expression.baseExpression
+            val conventionCallName = operationToken.toUnaryName()
+            return when {
+                operationToken == EXCLEXCL -> {
+                    buildCheckNotNullCall {
+                        source = expression.toFirSourceElement()
+                        argumentList = buildUnaryArgumentList(argument.toFirExpression("No operand"))
+                    }
+                }
+                conventionCallName != null -> {
+                    if (operationToken in OperatorConventions.INCREMENT_OPERATIONS) {
+                        return generateIncrementOrDecrementBlock(
+                            expression, expression.operationReference, argument,
+                            callName = conventionCallName,
+                            prefix = expression is KtPrefixExpression,
+                        ) { (this as KtExpression).toFirExpression("Incorrect expression inside inc/dec") }
+                    }
+                    buildFunctionCall {
+                        source = expression.toFirSourceElement()
+                        calleeReference = buildSimpleNamedReference {
+                            source = expression.operationReference.toFirSourceElement()
+                            name = conventionCallName
+                        }
+                        explicitReceiver = argument.toFirExpression("No operand")
+                    }
+                }
+                else -> throw IllegalStateException("Unexpected expression: ${expression.text}")
+            }
+        }
+
+        private fun splitToCalleeAndReceiver(
+            calleeExpression: KtExpression?,
+            defaultSource: FirPsiSourceElement<*>,
+        ): Pair<FirNamedReference, FirExpression?> {
+            return when (calleeExpression) {
+                is KtSimpleNameExpression -> buildSimpleNamedReference {
+                    source = calleeExpression.toFirSourceElement()
+                    name = calleeExpression.getReferencedNameAsName()
+                } to null
+
+                is KtParenthesizedExpression -> splitToCalleeAndReceiver(calleeExpression.expression, defaultSource)
+
+                null -> {
+                    buildErrorNamedReference { diagnostic = ConeSimpleDiagnostic("Call has no callee", DiagnosticKind.Syntax) } to null
+                }
+
+                is KtSuperExpression -> {
+                    buildErrorNamedReference {
+                        source = calleeExpression.toFirSourceElement()
+                        diagnostic = ConeSimpleDiagnostic("Super cannot be a callee", DiagnosticKind.SuperNotAllowed)
+                    } to null
+                }
+
+                else -> {
+                    buildSimpleNamedReference {
+                        source = defaultSource.fakeElement(FirFakeSourceElementKind.ImplicitInvokeCall)
+                        name = OperatorNameConventions.INVOKE
+                    } to calleeExpression.toFirExpression("Incorrect invoke receiver")
+                }
+            }
+        }
+
+        override fun visitCallExpression(expression: KtCallExpression, data: Unit): FirElement {
+            val source = expression.toFirSourceElement()
+            val (calleeReference, explicitReceiver) = splitToCalleeAndReceiver(expression.calleeExpression, source)
+
+            val result: FirQualifiedAccessBuilder = if (expression.valueArgumentList == null && expression.lambdaArguments.isEmpty()) {
+                FirQualifiedAccessExpressionBuilder().apply {
+                    this.source = source
+                    this.calleeReference = calleeReference
+                }
+            } else {
+                FirFunctionCallBuilder().apply {
+                    this.source = source
+                    this.calleeReference = calleeReference
+                    context.calleeNamesForLambda += calleeReference.name
+                    expression.extractArgumentsTo(this)
+                    context.calleeNamesForLambda.removeLast()
+                }
+            }
+
+            return result.apply {
+                this.explicitReceiver = explicitReceiver
+                for (typeArgument in expression.typeArguments) {
+                    typeArguments += typeArgument.convert<FirTypeProjection>()
+                }
+            }.build()
+        }
+
+        override fun visitArrayAccessExpression(expression: KtArrayAccessExpression, data: Unit): FirElement {
+            val arrayExpression = expression.arrayExpression
+            return buildFunctionCall {
+                val source: FirPsiSourceElement<*>
+                val getArgument = context.arraySetArgument.remove(expression)
+                if (getArgument != null) {
+                    calleeReference = buildSimpleNamedReference {
+                        source = expression.parent.toFirSourceElement()
+                        this.source = source.fakeElement(FirFakeSourceElementKind.ArrayAccessNameReference)
+                        name = OperatorNameConventions.SET
+                    }
+                } else {
+                    source = expression.toFirSourceElement()
+                    calleeReference = buildSimpleNamedReference {
+                        this.source = source.fakeElement(FirFakeSourceElementKind.ArrayAccessNameReference)
+                        name = OperatorNameConventions.GET
+                    }
+                }
+                this.source = source
+                explicitReceiver = arrayExpression.toFirExpression("No array expression")
+                argumentList = buildArgumentList {
+                    for (indexExpression in expression.indexExpressions) {
+                        arguments += indexExpression.toFirExpression("Incorrect index expression")
+                    }
+                    if (getArgument != null) {
+                        arguments += getArgument
+                    }
+                }
+            }
+        }
+
+        override fun visitQualifiedExpression(expression: KtQualifiedExpression, data: Unit): FirElement {
+            val selector = expression.selectorExpression
+                ?: return buildErrorExpression(
+                    expression.toFirSourceElement(), ConeSimpleDiagnostic("Qualified expression without selector", DiagnosticKind.Syntax),
+                )
+            val firSelector = selector.toFirExpression("Incorrect selector expression")
+            if (firSelector is FirQualifiedAccess) {
+                val receiver = expression.receiverExpression.toFirExpression("Incorrect receiver expression")
+
+                if (expression is KtSafeQualifiedExpression) {
+                    return firSelector.wrapWithSafeCall(receiver)
+                }
+
+                firSelector.replaceExplicitReceiver(receiver)
+            }
+            return firSelector
+        }
+
+        override fun visitThisExpression(expression: KtThisExpression, data: Unit): FirElement {
+            return buildThisReceiverExpression {
+                val sourceElement = expression.toFirSourceElement()
+                source = sourceElement
+                calleeReference = buildExplicitThisReference {
+                    source = sourceElement.fakeElement(FirFakeSourceElementKind.ExplicitThisOrSuperReference)
+                    labelName = expression.getLabelName()
+                }
+            }
+        }
+
+        override fun visitSuperExpression(expression: KtSuperExpression, data: Unit): FirElement {
+            val superType = expression.superTypeQualifier
+            val theSource = expression.toFirSourceElement()
+            return buildQualifiedAccessExpression {
+                this.source = theSource
+                calleeReference = buildExplicitSuperReference {
+                    source = theSource.fakeElement(FirFakeSourceElementKind.ExplicitThisOrSuperReference)
+                    labelName = expression.getLabelName()
+                    superTypeRef = superType.toFirOrImplicitType()
+                }
+            }
+        }
+
+        override fun visitParenthesizedExpression(expression: KtParenthesizedExpression, data: Unit): FirElement {
+            return expression.expression?.accept(this, data)
+                ?: buildErrorExpression(expression.toFirSourceElement(), ConeSimpleDiagnostic("Empty parentheses", DiagnosticKind.Syntax))
+        }
+
+        override fun visitLabeledExpression(expression: KtLabeledExpression, data: Unit): FirElement {
+            val sourceElement = expression.toFirSourceElement()
+            val label = expression.getTargetLabel()
+            val size = context.firLabels.size
+            if (label != null) {
+                context.firLabels += buildLabel {
+                    source = label.toFirPsiSourceElement()
+                    name = label.getReferencedName()
+                }
+            }
+            val result = expression.baseExpression?.accept(this, data)
+                ?: buildErrorExpression(sourceElement, ConeSimpleDiagnostic("Empty label", DiagnosticKind.Syntax))
+            if (size != context.firLabels.size) {
+                context.firLabels.removeLast()
+                println("Unused label: ${expression.text}")
+            }
+            return result
+        }
+
+        override fun visitAnnotatedExpression(expression: KtAnnotatedExpression, data: Unit): FirElement {
+            val rawResult = expression.baseExpression?.accept(this, data)
+//            return rawResult ?: buildErrorExpression(
+//                    expression.toFirSourceElement(),
+//                    FirSimpleDiagnostic("Strange annotated expression: ${rawResult?.render()}", DiagnosticKind.Syntax),
+//                )
+            // TODO !!!!!!!!
+            val result = rawResult as? FirAnnotationContainer
+                ?: return buildErrorExpression(
+                    expression.toFirSourceElement(),
+                    ConeSimpleDiagnostic("Strange annotated expression: ${rawResult?.render()}", DiagnosticKind.Syntax),
+                )
+            expression.extractAnnotationsTo(result.annotations as MutableList<FirAnnotationCall>)
+            return result
+        }
+
+        override fun visitThrowExpression(expression: KtThrowExpression, data: Unit): FirElement {
+            return buildThrowExpression {
+                source = expression.toFirSourceElement()
+                exception = expression.thrownExpression.toFirExpression("Nothing to throw")
+            }
+        }
+
+        override fun visitDestructuringDeclaration(multiDeclaration: KtDestructuringDeclaration, data: Unit): FirElement {
+            val baseVariable = generateTemporaryVariable(
+                baseSession, multiDeclaration.toFirSourceElement(), "destruct",
+                multiDeclaration.initializer.toFirExpression("Destructuring declaration without initializer"),
+            )
+            return generateDestructuringBlock(
+                baseSession,
+                multiDeclaration,
+                baseVariable,
+                tmpVariable = true,
+                extractAnnotationsTo = { extractAnnotationsTo(it) },
+            ) {
+                toFirOrImplicitType()
+            }
+        }
+
+        override fun visitClassLiteralExpression(expression: KtClassLiteralExpression, data: Unit): FirElement {
+            return buildGetClassCall {
+                source = expression.toFirSourceElement()
+                argumentList = buildUnaryArgumentList(expression.receiverExpression.toFirExpression("No receiver in class literal"))
+            }
+        }
+
+        override fun visitCallableReferenceExpression(expression: KtCallableReferenceExpression, data: Unit): FirElement {
+            return buildCallableReferenceAccess {
+                source = expression.toFirSourceElement()
+                calleeReference = buildSimpleNamedReference {
+                    source = expression.callableReference.toFirSourceElement()
+                    name = expression.callableReference.getReferencedNameAsName()
+                }
+                explicitReceiver = expression.receiverExpression?.toFirExpression("Incorrect receiver expression")
+                hasQuestionMarkAtLHS = expression.hasQuestionMarks
+            }
+        }
+
+        override fun visitCollectionLiteralExpression(expression: KtCollectionLiteralExpression, data: Unit): FirElement {
+            return buildArrayOfCall {
+                source = expression.toFirSourceElement()
+                argumentList = buildArgumentList {
+                    for (innerExpression in expression.getInnerExpressions()) {
+                        arguments += innerExpression.toFirExpression("Incorrect collection literal argument")
+                    }
+                }
+            }
+        }
+
+        override fun visitExpression(expression: KtExpression, data: Unit): FirElement {
+            return buildExpressionStub {
+                source = expression.toFirSourceElement()
+            }
+        }
+    }
+
+    private val extensionFunctionAnnotation = buildAnnotationCall {
+        annotationTypeRef = buildResolvedTypeRef {
+            type = ConeClassLikeTypeImpl(
+                ConeClassLikeLookupTagImpl(ClassId.fromString(EXTENSION_FUNCTION_ANNOTATION)),
+                emptyArray(),
+                isNullable = false
+            )
+        }
+        // TODO: actually we know where to resolve, but we don't have any symbol providers at this point
+        calleeReference = buildSimpleNamedReference {
+            name = Name.identifier("ExtensionFunctionType")
+        }
+    }
+}

--- a/tests/benchmark/kotlin.peg
+++ b/tests/benchmark/kotlin.peg
@@ -1,0 +1,449 @@
+file <- shebangLine? NL* fileAnnotation* _* packageHeader* _* importList* _* (filePart / _ / unparsable)* EOF
+filePart <- (topLevelObject / (statement _* semi))
+unparsable <- [^\n]+ NL* { printf("Syntax error at byte %d\n", $0s);}
+
+### Converted from peg/kotlin/KotlinParser.g4
+
+# options
+# // SECTION: general
+#kotlinFile <- shebangLine? NL* fileAnnotation* _* packageHeader _* importList _* topLevelObject* EOF
+#script <- shebangLine? NL* fileAnnotation* _* packageHeader _* importList _* (statement _* semi)* EOF
+shebangLine <- ShebangLine _* NL+
+fileAnnotation <- (AT_NO_WS / AT_PRE_WS) FILE NL* COLON _* NL* (LSQUARE _* unescapedAnnotation+ _* RSQUARE / unescapedAnnotation) _* NL*
+packageHeader <- PACKAGE _ <identifier> {printf("%s", $1);} _* semi?
+importList <- importHeader+
+importHeader <- IMPORT _ identifier (DOT MULT / importAlias)? _* semi? _*
+importAlias <- _ AS _ simpleIdentifier
+topLevelObject <- declaration _* semis?
+typeAlias <- modifiers? _* TYPE_ALIAS (_ / NL)* <simpleIdentifier> {printf("%s\n", $1);} _* (__* typeParameters)? __* ASSIGNMENT __* type
+declaration <- classDeclaration / objectDeclaration / functionDeclaration / propertyDeclaration / typeAlias
+
+# // SECTION: classes
+classDeclaration <- modifiers? (CLASS / (FUN __*)? INTERFACE) _ NL* <simpleIdentifier> {printf("%s\n", $1);} (__* typeParameters)? (__* primaryConstructor)? (__* COLON __* delegationSpecifiers)? (__* typeConstraints)? (__* classBody / __* enumClassBody)?
+primaryConstructor <- (modifiers? CONSTRUCTOR __*)? classParameters
+classBody <- LCURL __* classMemberDeclarations __* RCURL
+classParameters <- LPAREN __* (classParameter (__* COMMA __* classParameter)* (__* COMMA)?)? __* RPAREN
+classParameter <- (modifiers? _* VAL / modifiers? _* VAR / modifiers? _*)? __* <simpleIdentifier> {printf("%s\n", $1);} _* COLON __* type (__* ASSIGNMENT __* expression)?
+delegationSpecifiers <- annotatedDelegationSpecifier (__* COMMA __* annotatedDelegationSpecifier)*
+delegationSpecifier <- constructorInvocation / explicitDelegation / userType / functionType
+constructorInvocation <- userType _* valueArguments
+annotatedDelegationSpecifier <- annotation* __* delegationSpecifier
+explicitDelegation <- (userType / functionType) __* BY __* expression
+typeParameters <- LANGLE __* typeParameter (__* COMMA __* typeParameter)* (__* COMMA)? __* RANGLE
+typeParameter <- typeParameterModifiers? __* simpleIdentifier (__* COLON __* type)?
+typeConstraints <- WHERE __* typeConstraint (__* COMMA __* typeConstraint)*
+typeConstraint <- annotation* simpleIdentifier __* COLON __* type
+
+# // SECTION: classMembers
+classMemberDeclarations <- (classMemberDeclaration semis?)*
+classMemberDeclaration <- secondaryConstructor / anonymousInitializer / companionObject / declaration
+anonymousInitializer <- INIT __* block
+companionObject <- modifiers? COMPANION __* OBJECT <(__* simpleIdentifier)?> {printf("%s\n", $1e-$1s != 0 ? $1 : "Companion");} (__* COLON __* delegationSpecifiers)? (__* classBody)?
+functionValueParameters <- LPAREN __* (functionValueParameter (__* COMMA __* functionValueParameter)* (__* COMMA)?)? __* RPAREN
+functionValueParameter <- parameterModifiers? _* parameter (__* ASSIGNMENT __* expression)?
+functionDeclaration <- modifiers? _* FUN _* (__* typeParameters)? _* (__* receiverTypeAndDot)? __* <simpleIdentifier> {printf("%s\n", $1);} __* functionValueParameters _* (__* COLON __* type)? _* (__* typeConstraints)? _* (__* functionBody)?
+functionBody <- block / ASSIGNMENT __* expression
+variableDeclaration <- annotation* __* <simpleIdentifier> {printf("%s\n", $1);} (__* COLON __* type)?
+multiVariableDeclaration <- LPAREN __* variableDeclaration _* (__* COMMA __* variableDeclaration)* _* (__* COMMA)? __* RPAREN
+propertyDeclaration <- modifiers? _* (VAL / VAR) _ (__* typeParameters)? (__* receiverTypeAndDot)? (__* (multiVariableDeclaration / variableDeclaration)) (__* typeConstraints)? (__* (ASSIGNMENT __* expression / propertyDelegate))? (semi? _* setter (NL* semi? _* getter)? / semi? _* getter (NL* semi? _* setter)?)?
+propertyDelegate <- BY __* expression
+# TODO: better handling of empty getters and setters?
+getter <- (modifiers _*)? GET __* LPAREN __* RPAREN (__* COLON __* type)? __* functionBody / (modifiers _*)? GET !(_* [^;\r\n])
+setter <- (modifiers _*)? SET __* LPAREN __* parameterWithOptionalType (__* COMMA)? __* RPAREN (__* COLON __* type)? __* functionBody / (modifiers _*)? SET !(_* [^;\r\n])
+parametersWithOptionalType <- LPAREN __* (parameterWithOptionalType (__* COMMA __* parameterWithOptionalType)* (__* COMMA)?)? __* RPAREN
+parameterWithOptionalType <- parameterModifiers? simpleIdentifier __* (COLON __* type)?
+parameter <- simpleIdentifier __* COLON __* type
+objectDeclaration <- modifiers? _* OBJECT __* <simpleIdentifier> {printf("%s\n", $1);} (__* COLON __* delegationSpecifiers)? (__* classBody)?
+secondaryConstructor <- modifiers? CONSTRUCTOR __* functionValueParameters (__* COLON __* constructorDelegationCall)? __* block?
+constructorDelegationCall <- THIS __* valueArguments / SUPER __* valueArguments
+
+# // SECTION: enumClasses
+enumClassBody <- LCURL __* enumEntries? (__* SEMICOLON __* classMemberDeclarations)? __* RCURL
+enumEntries <- enumEntry (__* COMMA __* enumEntry)* __* COMMA?
+enumEntry <- (modifiers __*)? simpleIdentifier (__* valueArguments)? (__* classBody)?
+
+# // SECTION: types
+type <- typeModifiers? ( functionType / nullableType / parenthesizedType / typeReference)
+typeReference <- userType / DYNAMIC
+nullableType <- (typeReference / parenthesizedType) __* quest+
+quest <- !elvis (QUEST_WS / QUEST_NO_WS)
+userType <- simpleUserType (__* DOT __* simpleUserType)*
+simpleUserType <- simpleIdentifier (__* typeArguments)?
+typeProjection <- typeProjectionModifiers? type / MULT
+typeProjectionModifiers <- typeProjectionModifier+
+typeProjectionModifier <- varianceModifier __* / annotation
+functionType <- (receiverType __* DOT __*)? functionTypeParameters __* ARROW __* type
+functionTypeParameters <- LPAREN __* (parameter / type)? _* (__* COMMA __* (parameter / type))* _* (__* COMMA)? __* RPAREN
+parenthesizedType <- LPAREN __* type __* RPAREN
+receiverType <- (typeModifiers _*)? (nullableType / parenthesizedType / typeReference)
+# parenthesizedUserType <- LPAREN __* userType __* RPAREN / LPAREN __* parenthesizedUserType __* RPAREN
+receiverTypeAndDot <- (typeModifiers _*)? (nullableType __* DOT __* / parenthesizedType __* DOT __* / (simpleUserType __* DOT __*)+)
+
+# // SECTION: statements
+#statements <- (statement (semis statement)*)? semis?
+statements <- (statement _* (semis _* statement _*)*)? _* semis?
+statement <- (label / annotation)* ( declaration / assignment / loopStatement / expression)
+label <- simpleIdentifier (AT_POST_WS / AT_NO_WS) __*
+controlStructureBody <- block / statement
+block <- LCURL __* statements __* RCURL
+loopStatement <- forStatement / whileStatement / doWhileStatement
+forStatement <- FOR __* LPAREN _* annotation* _* (variableDeclaration / multiVariableDeclaration) _ IN _ inside_expression _* RPAREN __* (controlStructureBody)?
+whileStatement <- WHILE __* LPAREN _* inside_expression _* RPAREN __* controlStructureBody / WHILE __* LPAREN _* expression _* RPAREN __* SEMICOLON
+doWhileStatement <- DO __* controlStructureBody? __* WHILE __* LPAREN _* expression _* RPAREN
+assignment <- directlyAssignableExpression _* ASSIGNMENT __* expression / assignableExpression _* assignmentAndOperator __* expression
+semi <- (_* (SEMICOLON / NL) _*) NL*
+semis <- (_* (SEMICOLON / NL) _*)+
+
+# // SECTION: expressions
+expression <- disjunction
+disjunction <- conjunction (__* DISJ __* conjunction)*
+conjunction <- equality (__* CONJ __* equality)*
+equality <- comparison (_* equalityOperator __* comparison _*)*
+comparison <- genericCallLikeComparison (_* comparisonOperator __* genericCallLikeComparison _*)*
+genericCallLikeComparison <- infixOperation (_* callSuffix)*
+infixOperation <- elvisExpression (_* inOperator __* elvisExpression / _* isOperator __* type)*
+elvisExpression <- infixFunctionCall (__* elvis __* infixFunctionCall)*
+elvis <- QUEST_NO_WS COLON
+infixFunctionCall <- rangeExpression (_* simpleIdentifier __* rangeExpression)*
+rangeExpression <- additiveExpression (_* RANGE __* additiveExpression)*
+additiveExpression <- multiplicativeExpression (_* additiveOperator __* multiplicativeExpression)*
+multiplicativeExpression <- asExpression (_* multiplicativeOperator __* asExpression)*
+asExpression <- prefixUnaryExpression (__* asOperator __* type)*
+prefixUnaryExpression <- (unaryPrefix _*)* postfixUnaryExpression
+unaryPrefix <- annotation / label / prefixUnaryOperator __*
+postfixUnaryExpression <- primaryExpression (_* postfixUnarySuffix)+ / primaryExpression
+postfixUnarySuffix <- postfixUnaryOperator / typeArguments / callSuffix / indexingSuffix / navigationSuffix
+directlyAssignableExpression <- postfixUnaryExpression _* assignableSuffix / postfixUnaryExpression / simpleIdentifier / parenthesizedDirectlyAssignableExpression
+parenthesizedDirectlyAssignableExpression <- LPAREN __* inside_directlyAssignableExpression __* RPAREN
+assignableExpression <- prefixUnaryExpression / parenthesizedAssignableExpression
+parenthesizedAssignableExpression <- LPAREN __* inside_assignableExpression __* RPAREN
+assignableSuffix <- navigationSuffix / typeArguments / indexingSuffix
+indexingSuffix <- LSQUARE __* inside_expression (__* COMMA __* inside_expression)* (__* COMMA)? __* RSQUARE
+navigationSuffix <- __* memberAccessOperator __* (simpleIdentifier / parenthesizedExpression / CLASS)
+callSuffix <- typeArguments? _* valueArguments? _* annotatedLambda / typeArguments? _* valueArguments
+annotatedLambda <- annotation* _* label? __* lambdaLiteral
+typeArguments <- LANGLE __* typeProjection (__* COMMA __* typeProjection)* (__* COMMA)? __* RANGLE
+valueArguments <- LPAREN __* RPAREN / LPAREN __* inside_valueArgument (__* COMMA __* inside_valueArgument)* (__* COMMA)? __* RPAREN
+#valueArgument <- annotation? __* (simpleIdentifier __* ASSIGNMENT __*)? MULT? __* expression
+primaryExpression <- thisExpression / superExpression / ifExpression / whenExpression / tryExpression / jumpExpression / parenthesizedExpression/ callableReference / stringLiteral / functionLiteral / objectLiteral / collectionLiteral  / simpleIdentifier / literalConstant
+parenthesizedExpression <- LPAREN __* inside_expression __* RPAREN
+collectionLiteral <- LSQUARE __* inside_expression (__* COMMA __* inside_expression)* (__* COMMA)? __* RSQUARE / LSQUARE __* RSQUARE
+literalConstant <- BooleanLiteral / CharacterLiteral / NullLiteral / RealLiteral / UnsignedLiteral / LongLiteral / HexLiteral / BinLiteral / IntegerLiteral
+stringLiteral <- multiLineStringLiteral / lineStringLiteral
+lineStringLiteral <- QUOTE_OPEN (lineStringExpression / lineStringContent)* QUOTE_CLOSE
+#lineStringLiteral <- QUOTE_OPEN (lineStringExpression / EscapedIdentifier / UniCharacterLiteral / stringChar)* QUOTE_CLOSE
+multiLineStringLiteral <- TRIPLE_QUOTE_OPEN (multiLineStringExpression / multiLineStringContent / MultiLineStringQuote)* TRIPLE_QUOTE_CLOSE
+#multiLineStringLiteral <- TRIPLE_QUOTE_OPEN (multiLineStringExpression / MultiLineStringQuote / EscapedIdentifier / UniChracterLiteral / stringChar)* TRIPLE_QUOTE_CLOSE
+lineStringContent <- LineStrText / LineStrEscapedChar / LineStrRef
+lineStringExpression <- LineStrExprStart __* expression __* RCURL
+multiLineStringContent <- MultiLineStrRef / MultiLineStrText / MultiLineStringQuote
+multiLineStringExpression <- MultiLineStrExprStart __* expression __* RCURL
+
+inside_expression <- inside_disjunction
+inside_disjunction <- inside_conjunction (__* DISJ __* inside_conjunction)*
+inside_conjunction <- inside_equality (__* CONJ __* inside_equality)*
+inside_equality <- inside_comparison ((_ / NL)* equalityOperator __* inside_comparison (_ / NL)*)*
+inside_comparison <- inside_genericCallLikeComparison ((_ / NL)* comparisonOperator __* inside_genericCallLikeComparison (_ / NL)*)*
+inside_genericCallLikeComparison <- inside_infixOperation ((_ / NL)* callSuffix)*
+inside_infixOperation <- inside_elvisExpression ((_ / NL)* inOperator __* inside_elvisExpression / (_ / NL)* isOperator __* type)*
+inside_elvisExpression <- inside_infixFunctionCall (__* elvis __* inside_infixFunctionCall)*
+inside_infixFunctionCall <- inside_rangeExpression ((_ / NL)* simpleIdentifier __* inside_rangeExpression)*
+inside_rangeExpression <- inside_additiveExpression ((_ / NL)* RANGE __* inside_additiveExpression)*
+inside_additiveExpression <- inside_multiplicativeExpression ((_ / NL)* additiveOperator __* inside_multiplicativeExpression)*
+inside_multiplicativeExpression <- inside_asExpression ((_ / NL)* multiplicativeOperator __* inside_asExpression)*
+inside_asExpression <- inside_prefixUnaryExpression (__* asOperator __* type)*
+inside_prefixUnaryExpression <- (inside_unaryPrefix (_ / NL)*)* inside_postfixUnaryExpression
+inside_unaryPrefix <- annotation / label / prefixUnaryOperator __*
+inside_postfixUnaryExpression <- primaryExpression ((_ / NL)* inside_postfixUnarySuffix)+ / primaryExpression
+inside_postfixUnarySuffix <- postfixUnaryOperator / typeArguments / callSuffix / indexingSuffix / navigationSuffix
+inside_directlyAssignableExpression <- inside_postfixUnaryExpression (_ / NL)* assignableSuffix / inside_postfixUnaryExpression / simpleIdentifier / parenthesizedDirectlyAssignableExpression
+inside_assignableExpression <- inside_prefixUnaryExpression / parenthesizedAssignableExpression
+inside_valueArgument <- annotation? __* (simpleIdentifier __* ASSIGNMENT __*)? MULT? __* inside_expression
+
+
+#characterLiteral <- "'" (UniCharacterLiteral / EscapedIdentifier / [^\n\r'\\]) "'"
+#stringChar <- [^"]
+
+lambdaLiteral <- LCURL {printf("<lambda>\n");} __* statements __* RCURL / LCURL {printf("<lambda>\n");} __* lambdaParameters? __* ARROW __* statements __* RCURL
+lambdaParameters <- lambdaParameter (__* COMMA __* lambdaParameter)* (__* COMMA)?
+lambdaParameter <- variableDeclaration / multiVariableDeclaration (__* COLON __* type)?
+anonymousFunction <- FUN {printf("<anonymous function>");} (__* type __* DOT)? __* parametersWithOptionalType (__* COLON __* type)? (__* typeConstraints)? (__* functionBody)?
+functionLiteral <- lambdaLiteral / anonymousFunction
+objectLiteral <- OBJECT __* COLON __* delegationSpecifiers __* classBody / OBJECT __* classBody
+thisExpression <- THIS_AT / THIS !(Letter / UnicodeDigit)
+superExpression <- SUPER_AT / SUPER (LANGLE __* type __* RANGLE)? (AT_NO_WS simpleIdentifier)?
+ifExpression <- IF __* LPAREN __* expression __* RPAREN __* controlStructureBody? __* SEMICOLON? __* ELSE __* (controlStructureBody / SEMICOLON) / IF __* LPAREN __* expression __* RPAREN __* (controlStructureBody / SEMICOLON)
+whenSubject <- LPAREN (annotation* __* VAL __* variableDeclaration __* ASSIGNMENT __*)? expression RPAREN
+whenExpression <- WHEN __* whenSubject? __* LCURL __* (whenEntry __*)* __* RCURL
+whenEntry <- whenCondition (__* COMMA __* whenCondition)* (__* COMMA)? __* ARROW __* controlStructureBody semi? / ELSE __* ARROW __* controlStructureBody semi?
+whenCondition <- expression / rangeTest / typeTest
+rangeTest <- inOperator __* expression
+typeTest <- isOperator __* type
+tryExpression <- TRY __* block ((__* catchBlock)+ (__* finallyBlock)? / __* finallyBlock)
+catchBlock <- CATCH __* LPAREN _* (annotation _*)* simpleIdentifier _* COLON _* type (__* COMMA)? _* RPAREN __* block
+finallyBlock <- FINALLY __* block
+jumpExpression <- THROW __* expression / (RETURN_AT / RETURN) _* expression? / CONTINUE_AT / CONTINUE / BREAK_AT / BREAK
+callableReference <- (receiverType? __* COLONCOLON __* (simpleIdentifier / CLASS))
+assignmentAndOperator <- ADD_ASSIGNMENT / SUB_ASSIGNMENT / MULT_ASSIGNMENT / DIV_ASSIGNMENT / MOD_ASSIGNMENT
+equalityOperator <- EQEQEQ / EQEQ / EXCL_EQEQ / EXCL_EQ
+comparisonOperator <- LE / GE / LANGLE / RANGLE
+inOperator <- IN / NOT_IN
+isOperator <- IS / NOT_IS
+additiveOperator <- ADD / SUB
+multiplicativeOperator <- MULT / DIV / MOD
+asOperator <- AS_SAFE / AS
+prefixUnaryOperator <- INCR / DECR / SUB / ADD / excl
+postfixUnaryOperator <- INCR / DECR / EXCL_NO_WS excl
+excl <- EXCL_WS / EXCL_NO_WS
+memberAccessOperator <- DOT / safeNav / COLONCOLON
+safeNav <- QUEST_NO_WS DOT
+
+# // SECTION: modifiers
+modifiers <- (annotation / modifier)+
+parameterModifiers <- (annotation / parameterModifier)+
+modifier <- (classModifier / memberModifier / visibilityModifier / functionModifier / propertyModifier / inheritanceModifier / parameterModifier / platformModifier) __*
+typeModifiers <- typeModifier+
+typeModifier <- annotation / SUSPEND __*
+classModifier <- ENUM / SEALED / ANNOTATION / DATA / INNER
+memberModifier <- OVERRIDE / LATEINIT
+visibilityModifier <- PUBLIC / PRIVATE / INTERNAL / PROTECTED
+varianceModifier <- IN / OUT
+typeParameterModifiers <- typeParameterModifier+
+typeParameterModifier <- reificationModifier __* / varianceModifier __* / annotation
+functionModifier <- TAILREC / OPERATOR / INFIX / INLINE / EXTERNAL / SUSPEND
+propertyModifier <- CONST
+inheritanceModifier <- ABSTRACT / FINAL / OPEN
+parameterModifier <- VARARG / NOINLINE / CROSSINLINE
+reificationModifier <- REIFIED
+platformModifier <- EXPECT / ACTUAL
+
+# // SECTION: annotations
+annotation <- (singleAnnotation / multiAnnotation) __*
+singleAnnotation <- annotationUseSiteTarget __* unescapedAnnotation / (AT_NO_WS / AT_PRE_WS) unescapedAnnotation
+multiAnnotation <- annotationUseSiteTarget __* LSQUARE unescapedAnnotation+ RSQUARE / (AT_NO_WS / AT_PRE_WS) LSQUARE unescapedAnnotation+ RSQUARE
+annotationUseSiteTarget <- (AT_NO_WS / AT_PRE_WS) (FIELD / PROPERTY / GET / SET / RECEIVER / PARAM / SETPARAM / DELEGATE) __* COLON
+unescapedAnnotation <- constructorInvocation / userType
+
+# // SECTION: identifiers
+simpleIdentifier <- !(hardKeyword !(Letter / '_' / UnicodeDigit)) Identifier / ABSTRACT / ANNOTATION / BY / CATCH / COMPANION / CONSTRUCTOR / CROSSINLINE / DATA / DYNAMIC / ENUM / EXTERNAL / FINAL / FINALLY / GET / IMPORT / INFIX / INIT / INLINE / INNER / INTERNAL / LATEINIT / NOINLINE / OPEN / OPERATOR / OUT / OVERRIDE / PRIVATE / PROTECTED / PUBLIC / REIFIED / SEALED / TAILREC / SET / VARARG / WHERE / FIELD / PROPERTY / RECEIVER / PARAM / SETPARAM / DELEGATE / FILE / EXPECT / ACTUAL / CONST / SUSPEND
+identifier <- simpleIdentifier (__* DOT simpleIdentifier)*
+
+hardKeyword <- AS / BREAK / CLASS / CONTINUE / DO / ELSE / FOR / FUN / IF / IN / INTERFACE / IS / NullLiteral / OBJECT / PACKAGE / RETURN / SUPER / THIS / THROW / TRY / TYPE_ALIAS / TYPEOF / VAL / VAR / WHEN / WHILE / BooleanLiteral
+
+
+### Converted from peg/kotlin/KotlinLexer.g4
+
+
+# // SECTION: lexicalGeneral
+ShebangLine <- '#!' [^\r\n]*
+DelimitedComment <- '/*' (DelimitedComment / !'*/' .)* '*/'
+LineComment <- '//' [^\r\n]*
+#WS <- [\u0020\u0009\u000C]
+#NL <- '\n' / '\r' '\n'?
+Hidden <- DelimitedComment / LineComment / WS
+
+# // SECTION: separatorsAndOperations
+#RESERVED <- '...'
+DOT <- '.'
+COMMA <- ','
+LPAREN <- '('
+RPAREN <- ')'
+LSQUARE <- '['
+RSQUARE <- ']'
+LCURL <- '{'
+# /*
+# * When using another programming language (not Java) to generate a parser,
+# * please replace this code with the corresponding code of a programming language you are using.
+# */
+RCURL <- '}'
+MULT <- '*'
+MOD <- '%'
+DIV <- '/'
+ADD <- '+'
+SUB <- '-'
+INCR <- '++'
+DECR <- '--'
+CONJ <- '&&'
+DISJ <- '||'
+EXCL_WS <- '!' Hidden
+EXCL_NO_WS <- '!'
+COLON <- ':'
+SEMICOLON <- ';'
+ASSIGNMENT <- '=' !'='
+ADD_ASSIGNMENT <- '+='
+SUB_ASSIGNMENT <- '-='
+MULT_ASSIGNMENT <- '*='
+DIV_ASSIGNMENT <- '/='
+MOD_ASSIGNMENT <- '%='
+ARROW <- '->'
+#DOUBLE_ARROW <- '=>'
+RANGE <- '..'
+COLONCOLON <- '::'
+#DOUBLE_SEMICOLON <- ';;'
+#HASH <- '#'
+AT_NO_WS <- '@'
+AT_POST_WS <- '@' (Hidden / NL)
+AT_PRE_WS <- (Hidden / NL) '@'
+#AT_BOTH_WS <- (Hidden / NL) '@' (Hidden / NL)
+QUEST_WS <- '?' Hidden
+QUEST_NO_WS <- '?'
+LANGLE <- '<'
+RANGLE <- '>'
+LE <- '<='
+GE <- '>='
+EXCL_EQ <- '!='
+EXCL_EQEQ <- '!=='
+AS_SAFE <- 'as?'
+EQEQ <- '=='
+EQEQEQ <- '==='
+#SINGLE_QUOTE <- '\''
+
+# // SECTION: keywords
+RETURN_AT <- 'return@' Identifier
+CONTINUE_AT <- 'continue@' Identifier
+BREAK_AT <- 'break@' Identifier
+THIS_AT <- 'this@' Identifier
+SUPER_AT <- 'super@' Identifier
+FILE <- 'file' !(Letter / UnicodeDigit)
+FIELD <- 'field' !(Letter / UnicodeDigit)
+PROPERTY <- 'property' !(Letter / UnicodeDigit)
+GET <- 'get' !(Letter / UnicodeDigit)
+SET <- 'set' !(Letter / UnicodeDigit)
+RECEIVER <- 'receiver' !(Letter / UnicodeDigit)
+PARAM <- 'param' !(Letter / UnicodeDigit)
+SETPARAM <- 'setparam' !(Letter / UnicodeDigit)
+DELEGATE <- 'delegate' !(Letter / UnicodeDigit)
+PACKAGE <- 'package' !(Letter / UnicodeDigit)
+IMPORT <- 'import' !(Letter / UnicodeDigit)
+CLASS <- 'class' !(Letter / UnicodeDigit)
+INTERFACE <- 'interface' !(Letter / UnicodeDigit)
+FUN <- 'fun' !(Letter / UnicodeDigit)
+OBJECT <- 'object' !(Letter / UnicodeDigit)
+VAL <- 'val' !(Letter / UnicodeDigit)
+VAR <- 'var' !(Letter / UnicodeDigit)
+TYPE_ALIAS <- 'typealias' !(Letter / UnicodeDigit)
+CONSTRUCTOR <- 'constructor' !(Letter / UnicodeDigit)
+BY <- 'by' !(Letter / UnicodeDigit)
+COMPANION <- 'companion' !(Letter / UnicodeDigit)
+INIT <- 'init' !(Letter / UnicodeDigit)
+THIS <- 'this' !(Letter / UnicodeDigit)
+SUPER <- 'super' !(Letter / UnicodeDigit)
+TYPEOF <- 'typeof' !(Letter / UnicodeDigit)
+WHERE <- 'where' !(Letter / UnicodeDigit)
+IF <- 'if' !(Letter / UnicodeDigit)
+ELSE <- 'else' !(Letter / UnicodeDigit)
+WHEN <- 'when' !(Letter / UnicodeDigit)
+TRY <- 'try' !(Letter / UnicodeDigit)
+CATCH <- 'catch' !(Letter / UnicodeDigit)
+FINALLY <- 'finally' !(Letter / UnicodeDigit)
+FOR <- 'for' !(Letter / UnicodeDigit)
+DO <- 'do' !(Letter / UnicodeDigit)
+WHILE <- 'while' !(Letter / UnicodeDigit)
+THROW <- 'throw' !(Letter / UnicodeDigit)
+RETURN <- 'return' !(Letter / UnicodeDigit)
+CONTINUE <- 'continue' !(Letter / UnicodeDigit)
+BREAK <- 'break' !(Letter / UnicodeDigit)
+AS <- 'as' !(Letter / UnicodeDigit)
+IS <- 'is' !(Letter / UnicodeDigit)
+IN <- 'in' !(Letter / UnicodeDigit)
+NOT_IS <- '!is' !(Letter / UnicodeDigit)
+NOT_IN <- '!in' !(Letter / UnicodeDigit)
+OUT <- 'out' !(Letter / UnicodeDigit)
+DYNAMIC <- 'dynamic' !(Letter / UnicodeDigit)
+
+# // SECTION: lexicalModifiers
+PUBLIC <- 'public' !(Letter / UnicodeDigit)
+PRIVATE <- 'private' !(Letter / UnicodeDigit)
+PROTECTED <- 'protected' !(Letter / UnicodeDigit)
+INTERNAL <- 'internal' !(Letter / UnicodeDigit)
+ENUM <- 'enum' !(Letter / UnicodeDigit)
+SEALED <- 'sealed' !(Letter / UnicodeDigit)
+ANNOTATION <- 'annotation' !(Letter / UnicodeDigit)
+DATA <- 'data' !(Letter / UnicodeDigit)
+INNER <- 'inner' !(Letter / UnicodeDigit)
+TAILREC <- 'tailrec' !(Letter / UnicodeDigit)
+OPERATOR <- 'operator' !(Letter / UnicodeDigit)
+INLINE <- 'inline' !(Letter / UnicodeDigit)
+INFIX <- 'infix' !(Letter / UnicodeDigit)
+EXTERNAL <- 'external' !(Letter / UnicodeDigit)
+SUSPEND <- 'suspend' !(Letter / UnicodeDigit)
+OVERRIDE <- 'override' !(Letter / UnicodeDigit)
+ABSTRACT <- 'abstract' !(Letter / UnicodeDigit)
+FINAL <- 'final' !(Letter / UnicodeDigit)
+OPEN <- 'open' !(Letter / UnicodeDigit)
+CONST <- 'const' !(Letter / UnicodeDigit)
+LATEINIT <- 'lateinit' !(Letter / UnicodeDigit)
+VARARG <- 'vararg' !(Letter / UnicodeDigit)
+NOINLINE <- 'noinline' !(Letter / UnicodeDigit)
+CROSSINLINE <- 'crossinline' !(Letter / UnicodeDigit)
+REIFIED <- 'reified' !(Letter / UnicodeDigit)
+EXPECT <- 'expect' !(Letter / UnicodeDigit)
+ACTUAL <- 'actual' !(Letter / UnicodeDigit)
+
+# // SECTION: literals
+DecDigit <- [0-9]
+DecDigitNoZero <- [1-9]
+DecDigitOrSeparator <- DecDigit / '_'
+DecDigits <- DecDigit DecDigitOrSeparator* / DecDigit
+DoubleExponent <- [eE] [-+]? DecDigits
+RealLiteral <- FloatLiteral / DoubleLiteral
+FloatLiteral <- DoubleLiteral [fF] / DecDigits [fF]
+DoubleLiteral <- DecDigits? '.' DecDigits DoubleExponent? / DecDigits DoubleExponent
+IntegerLiteral <- DecDigitNoZero DecDigitOrSeparator* / DecDigit
+#IntegerLiteral <- DecDigitNoZero DecDigitOrSeparator* DecDigit / DecDigit
+HexDigit <- [0-9a-fA-F]
+HexDigitOrSeparator <- HexDigit / '_'
+HexLiteral <- '0' [xX] HexDigit HexDigitOrSeparator* / '0' [xX] HexDigit
+BinDigit <- [01]
+BinDigitOrSeparator <- BinDigit / '_'
+BinLiteral <- '0' [bB] BinDigit BinDigitOrSeparator* / '0' [bB] BinDigit
+UnsignedLiteral <- (HexLiteral / BinLiteral / IntegerLiteral) [uU] [lL]?
+LongLiteral <- (HexLiteral / BinLiteral / IntegerLiteral) [lL]
+BooleanLiteral <- 'true'/ 'false'
+NullLiteral <- 'null'
+CharacterLiteral <- '\'' (EscapeSeq / [^\n\r'\\]) '\''
+
+# // SECTION: lexicalIdentifiers
+#UnicodeDigit <- UNICODE_CLASS_ND
+Identifier <- '`' [^`\r\n]+ '`' / (Letter / '_') (Letter / '_' / UnicodeDigit)*
+IdentifierOrSoftKey <- Identifier / ABSTRACT / ANNOTATION / BY / CATCH / COMPANION / CONSTRUCTOR / CROSSINLINE / DATA / DYNAMIC / ENUM / EXTERNAL / FINAL / FINALLY / IMPORT / INFIX / INIT / INLINE / INNER / INTERNAL / LATEINIT / NOINLINE / OPEN / OPERATOR / OUT / OVERRIDE / PRIVATE / PROTECTED / PUBLIC / REIFIED / SEALED / TAILREC / VARARG / WHERE / GET / SET / FIELD / PROPERTY / RECEIVER / PARAM / SETPARAM / DELEGATE / FILE / EXPECT / ACTUAL / CONST / SUSPEND
+FieldIdentifier <- '$' IdentifierOrSoftKey
+UniCharacterLiteral <- '\\' 'u' HexDigit HexDigit HexDigit HexDigit
+EscapedIdentifier <- '\\' ('t' / 'b' / 'r' / 'n' / '\'' / '"' / '\\' / '$')
+EscapeSeq <- UniCharacterLiteral / EscapedIdentifier
+
+# // SECTION: characters
+Letter <- [\u0041-\u005A\u0061-\u007A\u00AA\u00B5\u00BA\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u02C1\u02C6-\u02D1\u02E0-\u02E4\u02EC\u02EE\u0370-\u0374\u0376-\u0377\u037A-\u037D\u0386\u0388-\u038A\u038C\u038E-\u03A1\u03A3-\u03F5\u03F7-\u0481\u048A-\u0527\u0531-\u0556\u0559\u0561-\u0587\u05D0-\u05EA\u05F0-\u05F2\u0620-\u064A\u066E-\u066F\u0671-\u06D3\u06D5\u06E5-\u06E6\u06EE-\u06EF\u06FA-\u06FC\u06FF\u0710\u0712-\u072F\u074D-\u07A5\u07B1\u07CA-\u07EA\u07F4-\u07F5\u07FA\u0800-\u0815\u081A\u0824\u0828\u0840-\u0858\u08A0\u08A2-\u08AC\u0904-\u0939\u093D\u0950\u0958-\u0961\u0971-\u0977\u0979-\u097F\u0985-\u098C\u098F-\u0990\u0993-\u09A8\u09AA-\u09B0\u09B2\u09B6-\u09B9\u09BD\u09CE\u09DC-\u09DD\u09DF-\u09E1\u09F0-\u09F1\u0A05-\u0A0A\u0A0F-\u0A10\u0A13-\u0A28\u0A2A-\u0A30\u0A32-\u0A33\u0A35-\u0A36\u0A38-\u0A39\u0A59-\u0A5C\u0A5E\u0A72-\u0A74\u0A85-\u0A8D\u0A8F-\u0A91\u0A93-\u0AA8\u0AAA-\u0AB0\u0AB2-\u0AB3\u0AB5-\u0AB9\u0ABD\u0AD0\u0AE0-\u0AE1\u0B05-\u0B0C\u0B0F-\u0B10\u0B13-\u0B28\u0B2A-\u0B30\u0B32-\u0B33\u0B35-\u0B39\u0B3D\u0B5C-\u0B5D\u0B5F-\u0B61\u0B71\u0B83\u0B85-\u0B8A\u0B8E-\u0B90\u0B92-\u0B95\u0B99-\u0B9A\u0B9C\u0B9E-\u0B9F\u0BA3-\u0BA4\u0BA8-\u0BAA\u0BAE-\u0BB9\u0BD0\u0C05-\u0C0C\u0C0E-\u0C10\u0C12-\u0C28\u0C2A-\u0C33\u0C35-\u0C39\u0C3D\u0C58-\u0C59\u0C60-\u0C61\u0C85-\u0C8C\u0C8E-\u0C90\u0C92-\u0CA8\u0CAA-\u0CB3\u0CB5-\u0CB9\u0CBD\u0CDE\u0CE0-\u0CE1\u0CF1-\u0CF2\u0D05-\u0D0C\u0D0E-\u0D10\u0D12-\u0D3A\u0D3D\u0D4E\u0D60-\u0D61\u0D7A-\u0D7F\u0D85-\u0D96\u0D9A-\u0DB1\u0DB3-\u0DBB\u0DBD\u0DC0-\u0DC6\u0E01-\u0E30\u0E32-\u0E33\u0E40-\u0E46\u0E81-\u0E82\u0E84\u0E87-\u0E88\u0E8A\u0E8D\u0E94-\u0E97\u0E99-\u0E9F\u0EA1-\u0EA3\u0EA5\u0EA7\u0EAA-\u0EAB\u0EAD-\u0EB0\u0EB2-\u0EB3\u0EBD\u0EC0-\u0EC4\u0EC6\u0EDC-\u0EDF\u0F00\u0F40-\u0F47\u0F49-\u0F6C\u0F88-\u0F8C\u1000-\u102A\u103F\u1050-\u1055\u105A-\u105D\u1061\u1065-\u1066\u106E-\u1070\u1075-\u1081\u108E\u10A0-\u10C5\u10C7\u10CD\u10D0-\u10FA\u10FC-\u1248\u124A-\u124D\u1250-\u1256\u1258\u125A-\u125D\u1260-\u1288\u128A-\u128D\u1290-\u12B0\u12B2-\u12B5\u12B8-\u12BE\u12C0\u12C2-\u12C5\u12C8-\u12D6\u12D8-\u1310\u1312-\u1315\u1318-\u135A\u1380-\u138F\u13A0-\u13F4\u1401-\u166C\u166F-\u167F\u1681-\u169A\u16A0-\u16EA\u16EE-\u16F0\u1700-\u170C\u170E-\u1711\u1720-\u1731\u1740-\u1751\u1760-\u176C\u176E-\u1770\u1780-\u17B3\u17D7\u17DC\u1820-\u1877\u1880-\u18A8\u18AA\u18B0-\u18F5\u1900-\u191C\u1950-\u196D\u1970-\u1974\u1980-\u19AB\u19C1-\u19C7\u1A00-\u1A16\u1A20-\u1A54\u1AA7\u1B05-\u1B33\u1B45-\u1B4B\u1B83-\u1BA0\u1BAE-\u1BAF\u1BBA-\u1BE5\u1C00-\u1C23\u1C4D-\u1C4F\u1C5A-\u1C7D\u1CE9-\u1CEC\u1CEE-\u1CF1\u1CF5-\u1CF6\u1D00-\u1DBF\u1E00-\u1F15\u1F18-\u1F1D\u1F20-\u1F45\u1F48-\u1F4D\u1F50-\u1F57\u1F59\u1F5B\u1F5D\u1F5F-\u1F7D\u1F80-\u1FB4\u1FB6-\u1FBC\u1FBE\u1FC2-\u1FC4\u1FC6-\u1FCC\u1FD0-\u1FD3\u1FD6-\u1FDB\u1FE0-\u1FEC\u1FF2-\u1FF4\u1FF6-\u1FFC\u2071\u207F\u2090-\u209C\u2102\u2107\u210A-\u2113\u2115\u2119-\u211D\u2124\u2126\u2128\u212A-\u212D\u212F-\u2139\u213C-\u213F\u2145-\u2149\u214E\u2160-\u2188\u2C00-\u2C2E\u2C30-\u2C5E\u2C60-\u2CE4\u2CEB-\u2CEE\u2CF2-\u2CF3\u2D00-\u2D25\u2D27\u2D2D\u2D30-\u2D67\u2D6F\u2D80-\u2D96\u2DA0-\u2DA6\u2DA8-\u2DAE\u2DB0-\u2DB6\u2DB8-\u2DBE\u2DC0-\u2DC6\u2DC8-\u2DCE\u2DD0-\u2DD6\u2DD8-\u2DDE\u2E2F\u3005-\u3007\u3021-\u3029\u3031-\u3035\u3038-\u303C\u3041-\u3096\u309D-\u309F\u30A1-\u30FA\u30FC-\u30FF\u3105-\u312D\u3131-\u318E\u31A0-\u31BA\u31F0-\u31FF\u3400\u4DB5\u4E00\u9FCC\uA000-\uA48C\uA4D0-\uA4FD\uA500-\uA60C\uA610-\uA61F\uA62A-\uA62B\uA640-\uA66E\uA67F-\uA697\uA6A0-\uA6EF\uA717-\uA71F\uA722-\uA788\uA78B-\uA78E\uA790-\uA793\uA7A0-\uA7AA\uA7F8-\uA801\uA803-\uA805\uA807-\uA80A\uA80C-\uA822\uA840-\uA873\uA882-\uA8B3\uA8F2-\uA8F7\uA8FB\uA90A-\uA925\uA930-\uA946\uA960-\uA97C\uA984-\uA9B2\uA9CF\uAA00-\uAA28\uAA40-\uAA42\uAA44-\uAA4B\uAA60-\uAA76\uAA7A\uAA80-\uAAAF\uAAB1\uAAB5-\uAAB6\uAAB9-\uAABD\uAAC0\uAAC2\uAADB-\uAADD\uAAE0-\uAAEA\uAAF2-\uAAF4\uAB01-\uAB06\uAB09-\uAB0E\uAB11-\uAB16\uAB20-\uAB26\uAB28-\uAB2E\uABC0-\uABE2\uAC00\uD7A3\uD7B0-\uD7C6\uD7CB-\uD7FB\uF900-\uFA6D\uFA70-\uFAD9\uFB00-\uFB06\uFB13-\uFB17\uFB1D\uFB1F-\uFB28\uFB2A-\uFB36\uFB38-\uFB3C\uFB3E\uFB40-\uFB41\uFB43-\uFB44\uFB46-\uFBB1\uFBD3-\uFD3D\uFD50-\uFD8F\uFD92-\uFDC7\uFDF0-\uFDFB\uFE70-\uFE74\uFE76-\uFEFC\uFF21-\uFF3A\uFF41-\uFF5A\uFF66-\uFFBE\uFFC2-\uFFC7\uFFCA-\uFFCF\uFFD2-\uFFD7\uFFDA-\uFFDC]
+UnicodeDigit <- [\u0030-\u0039\u0660-\u0669\u06F0-\u06F9\u07C0-\u07C9\u0966-\u096F\u09E6-\u09EF\u0A66-\u0A6F\u0AE6-\u0AEF\u0B66-\u0B6F\u0BE6-\u0BEF\u0C66-\u0C6F\u0CE6-\u0CEF\u0D66-\u0D6F\u0E50-\u0E59\u0ED0-\u0ED9\u0F20-\u0F29\u1040-\u1049\u1090-\u1099\u17E0-\u17E9\u1810-\u1819\u1946-\u194F\u19D0-\u19D9\u1A80-\u1A89\u1A90-\u1A99\u1B50-\u1B59\u1BB0-\u1BB9\u1C40-\u1C49\u1C50-\u1C59\uA620-\uA629\uA8D0-\uA8D9\uA900-\uA909\uA9D0-\uA9D9\uAA50-\uAA59\uABF0-\uABF9\uFF10-\uFF19]
+
+# // SECTION: strings
+QUOTE_OPEN <- '"' !'""'
+TRIPLE_QUOTE_OPEN <- '"""'
+QUOTE_CLOSE <- '"'
+LineStrRef <- FieldIdentifier
+#LineStrText <- [^\\"$]+ / '$'
+LineStrText <- [^\\"$]+ / '$'
+LineStrEscapedChar <- EscapedIdentifier / UniCharacterLiteral
+LineStrExprStart <- '${'
+TRIPLE_QUOTE_CLOSE <- '"""""'/ '""""' / '"""'
+MultiLineStringQuote <- '""' !'"' / '"' !'""'
+MultiLineStrRef <- FieldIdentifier
+#MultiLineStrText <- !('"' / '$')+ / '$'
+MultiLineStrText <- [^"$]+ / '$'
+MultiLineStrExprStart <- '${'
+
+_ <- (WS / DelimitedComment / LineComment)+
+__ <- ([ \t\f\r\n] / DelimitedComment / LineComment)+
+WS <- [ \t\f]
+NL <- _* ('\n' / '\r' '\n'?) _*
+EOF <- !.
+
+%%
+
+int main(int argc, char **argv) {
+    int ret;
+    pcc_context_t *ctx = pcc_create(NULL);
+    while (pcc_parse(ctx, &ret));
+    pcc_destroy(ctx);
+    return 0;
+}

--- a/tests/benchmark/test.peg
+++ b/tests/benchmark/test.peg
@@ -1,0 +1,14 @@
+MAIN <- (COMPLEX COMPLEX / STRINGS / SIMPLE)*
+COMPLEX <- <"COMPLEX">
+SIMPLE <- .
+STRINGS <- "A" "B"
+
+%%
+
+int main(int argc, char **argv) {
+    int ret;
+    pcc_context_t *ctx = pcc_create(NULL);
+    while (pcc_parse(ctx, &ret));
+    pcc_destroy(ctx);
+    return 0;
+}


### PR DESCRIPTION
Hello @arithy and @andrewchambers,

Here is my unfinished attempt on adding optimization phase to packcc, as I mentioned in https://github.com/arithy/packcc/issues/46#issuecomment-936353311.

## Possible optimizations:

 - Inline simple terminal symbols (multi pass) (no quantity, alternation, captures/action/error)
 - Join adjacent strings
 - Inline terminal symbols (multi pass) (with captures/action/error)
 - Join repeated rules to single quantity
 - Extract alternation/quantity to separate rules (might or might not help, probably depends on grammar)

## Example

A -> B / C
B -> "B"
C -> D (E / F)
D -> B B
E -> "E"*
F -> "F"

This could be optimized to:

A -> "B" / C
C -> "BB" C1
C1 -> "E"* / "F"

## Disclaimer

The code is far from perfect, in fact it barely works. I'm also pretty sure that there are some memory leaks and other problems. This is not intended to be merged, only as an inspiration for whoever might want to continue exploring the ways to make packcc to generate faster code.