### PR TITLE
#line directive support

### DIFF
--- a/src/packcc.c
+++ b/src/packcc.c
@@ -2238,14 +2238,21 @@ static bool_t parse_directive_include_(context_t *ctx, const char *name, char_ar
         const size_t p = ctx->bufcur;
         if (match_code_block(ctx)) {
             const size_t q = ctx->bufcur;
+			char buf[1024];
+			int len;
+			len = snprintf(buf, 1024, "#line " FMT_LU " \"%s\"\n", l+1, ctx->iname);
             match_spaces(ctx);
             if (output1 != NULL) {
+				char_array__append(output1, buf, len);
                 char_array__append(output1, ctx->buffer.buf + p + 1, q - p - 2);
                 char_array__add(output1, '\n');
+				char_array__append(output1, "#\n", 2);
             }
             if (output2 != NULL) {
+				char_array__append(output2, buf, len);
                 char_array__append(output2, ctx->buffer.buf + p + 1, q - p - 2);
                 char_array__add(output2, '\n');
+				char_array__append(output2, "#\n", 2);
             }
         }
         else {
@@ -4356,7 +4363,9 @@ static bool_t generate(context_t *ctx) {
                         );
                         k++;
                     }
+					fprintf_e(sstream, "#line " FMT_LU " \"%s\"\n", r->line+1, ctx->iname);
                     write_code_block(sstream, s, strlen(s), 4);
+					fprintf_e(sstream, "#\n");
                     k = c->len;
                     while (k > 0) {
                         k--;
@@ -4574,6 +4583,7 @@ static bool_t generate(context_t *ctx) {
         match_eol(ctx);
         if (!match_eof(ctx)) fputc_e('\n', sstream);
         commit_buffer(ctx);
+		fprintf_e(sstream, "#line " FMT_LU " \"%s\"\n", ctx->linenum+1, ctx->iname);
         while (refill_buffer(ctx, ctx->buffer.max) > 0) {
             const size_t n = (ctx->buffer.len > 0 && ctx->buffer.buf[ctx->buffer.len - 1] == '\r') ? ctx->buffer.len - 1 : ctx->buffer.len;
             write_text(sstream, ctx->buffer.buf, n);

--- a/src/packcc.c
+++ b/src/packcc.c
@@ -2238,21 +2238,21 @@ static bool_t parse_directive_include_(context_t *ctx, const char *name, char_ar
         const size_t p = ctx->bufcur;
         if (match_code_block(ctx)) {
             const size_t q = ctx->bufcur;
-			char buf[1024];
-			int len;
-			len = snprintf(buf, 1024, "#line " FMT_LU " \"%s\"\n", l+1, ctx->iname);
+            char buf[1024];
+            int len;
+            len = snprintf(buf, 1024, "#line " FMT_LU " \"%s\"\n", l+1, ctx->iname);
             match_spaces(ctx);
             if (output1 != NULL) {
-				char_array__append(output1, buf, len);
+                char_array__append(output1, buf, len);
                 char_array__append(output1, ctx->buffer.buf + p + 1, q - p - 2);
                 char_array__add(output1, '\n');
-				char_array__append(output1, "#\n", 2);
+                char_array__append(output1, "#\n", 2);
             }
             if (output2 != NULL) {
-				char_array__append(output2, buf, len);
+                char_array__append(output2, buf, len);
                 char_array__append(output2, ctx->buffer.buf + p + 1, q - p - 2);
                 char_array__add(output2, '\n');
-				char_array__append(output2, "#\n", 2);
+                char_array__append(output2, "#\n", 2);
             }
         }
         else {
@@ -4363,9 +4363,9 @@ static bool_t generate(context_t *ctx) {
                         );
                         k++;
                     }
-					fprintf_e(sstream, "#line " FMT_LU " \"%s\"\n", r->line+1, ctx->iname);
+                    fprintf_e(sstream, "#line " FMT_LU " \"%s\"\n", r->line+1, ctx->iname);
                     write_code_block(sstream, s, strlen(s), 4);
-					fprintf_e(sstream, "#\n");
+                    fprintf_e(sstream, "#\n");
                     k = c->len;
                     while (k > 0) {
                         k--;
@@ -4583,7 +4583,7 @@ static bool_t generate(context_t *ctx) {
         match_eol(ctx);
         if (!match_eof(ctx)) fputc_e('\n', sstream);
         commit_buffer(ctx);
-		fprintf_e(sstream, "#line " FMT_LU " \"%s\"\n", ctx->linenum+1, ctx->iname);
+        fprintf_e(sstream, "#line " FMT_LU " \"%s\"\n", ctx->linenum+1, ctx->iname);
         while (refill_buffer(ctx, ctx->buffer.max) > 0) {
             const size_t n = (ctx->buffer.len > 0 && ctx->buffer.buf[ctx->buffer.len - 1] == '\r') ? ctx->buffer.len - 1 : ctx->buffer.len;
             write_text(sstream, ctx->buffer.buf, n);


### PR DESCRIPTION
I added #line directives to the generated output c code, to assist with debugging and build error feedback.  This is especially helpful when iteratively building and fixing errors in vi using `:make`.  With this change vi moves to the location with the error in the original source rather than the generated c file.

It's not perfect or ready for merging yet but I opened this pull request to get your feedback on whether this is a feature you want and to see if you have any guidance on the issues that remain with this feature:

- [ ] The line numbers emitted for rule actions are approximate - they are the line number in the original source of the rule rather than the action.
- [ ] Eliminate the need for awk postprocessing.
- [x] Make feature conditional on a command line toggle?
- [ ] Replace snprintf with fixed size buffer with whatever would be idiomatic for this project.

Currently the generated result needs post processing to resolve the generated line numbers for switching the reported context back to the generated c code when leaving an inserted block.  To do this properly the generator needs to keep track of the lines output to the generated code, but for now I've just had it write out a bare "#" line.  Then an awk script can post process that to fill out the correct directives like this:

~~~sh
echo "$(awk '/^#$/ {printf "#line %d \"%s\"\n",NR+1,FILENAME; next;} {print;}' generated.c)" > generated.c
~~~