### PR TITLE
Handle C directives in source as any other code

### DIFF
--- a/src/packcc.c
+++ b/src/packcc.c
@@ -1883,22 +1883,6 @@ static bool_t match_section_line_(context_t *ctx, const char *head) {
     return FALSE;
 }
 
-static bool_t match_section_line_continuable_(context_t *ctx, const char *head) {
-    if (match_string(ctx, head)) {
-        while (!match_eof(ctx)) {
-            const size_t p = ctx->bufcur;
-            if (match_eol(ctx)) {
-                if (ctx->buffer.buf[p - 1] != '\\') break;
-            }
-            else {
-                match_character_any(ctx);
-            }
-        }
-        return TRUE;
-    }
-    return FALSE;
-}
-
 static bool_t match_section_block_(context_t *ctx, const char *left, const char *right, const char *name) {
     const size_t l = ctx->linenum;
     const size_t m = column_number(ctx);
@@ -1941,10 +1925,6 @@ static bool_t match_quotation_(context_t *ctx, const char *left, const char *rig
         return TRUE;
     }
     return FALSE;
-}
-
-static bool_t match_directive_c(context_t *ctx) {
-    return match_section_line_continuable_(ctx, "#");
 }
 
 static bool_t match_comment(context_t *ctx) {
@@ -2014,7 +1994,6 @@ static bool_t match_code_block(context_t *ctx) {
                 break;
             }
             if (
-                match_directive_c(ctx) ||
                 match_comment_c(ctx) ||
                 match_comment_cxx(ctx) ||
                 match_quotation_single(ctx) ||


### PR DESCRIPTION
# Problem

Consider this PEG code:
```
%header { #include "stdio.h" }
```
PackCC will fail to parse this, complaining about `Premature EOF in code block`. The reason is that it tries to parse the include directive, which consumes everything up to the newline, including the closing brace.

# Solution

I propose to drop the special handling of C directives in source block. The only directive I can think of that would require this special handling would be a set of macros that builds a struct (or some other "scope") from simpler blocks, e.g.:
```
#define START_STRUCT_1(NAME) struct NAME {
#define START_STRUCT_2(NAME, SUFFIX) struct  NAME ## _ ## SUFFIX {
#define END_STRUCT }
```
This very synthetic example would result in unbalanced braces, but I think it would not be a very common occurrence. Definitely way more rare than including a single file and writing the directive on one line.

# Possible alternatives

It could be also possible to check if the directive ends with closing brace followed by new line and stop parsing there. However it would probably be much more complicated and it still could break in some cases, such se with the `END_STRUCT` macro in the example above.

Another option would be to only parse `#define`s as directive and process `#include`, `#pragma` and other directives as regular code. This would allow one-line directives, while making the macros safe (and requiring them to always be in multi-line source blocks). This would probably work as well, but it makes things bit more complex unnecessarily .