### PR TITLE
add memory measurement to benchmark script

### DIFF
--- a/benchmark/benchmark.sh
+++ b/benchmark/benchmark.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 #
-# Generates, builds and runs parsers from grammar directory for each git reference supplied as argument.
-# Each action is performed multiple times and the times are averaged. First reference is always
-# taken as a "baseline" and others are compared to it. This should allow to compare how any given commit
-# affects PackCCs performance.
+# Generates, builds and runs parsers from grammars directory for each git reference supplied as argument.
+# Each action is performed multiple times and the times are averaged. Peak memory consumption is also measured.
+# First reference is always taken as a "baseline" and others are compared to it. This should allow to compare
+# how any given commit affects PackCCs performance.
 #
 # Usage:
 #   ./benchmark.sh <git ref> ...
@@ -35,23 +35,36 @@ format() {
     elif [ $((TIME / 1000)) -gt 10 ]; then
         echo "$((TIME / 1000)) us"
     else
-        echo "$((TIME)) ns"
+        echo "$TIME ns"
+    fi
+}
+
+format_mem() {
+    MEM="$1"
+    if [ -z "$TIME_CMD" ]; then
+        echo "??? kB"
+    elif [ $((MEM / 1048576)) -gt 10 ]; then
+        echo "$((MEM / 1048576)) GB"
+    elif [ $((MEM / 1024)) -gt 10 ]; then
+        echo "$((MEM / 1024)) MB"
+    else
+        echo "$MEM kB"
     fi
 }
 
 measure() {
     COUNT="$1"
     shift
+    MEM=0
+    if [ "$TIME_CMD" ]; then
+        MEM="$(${TIME_CMD[@]} -f %M "$@" 2>&1 >/dev/null)"
+    fi
     START="$(date '+%s%N')"
     for ((i=0; i<COUNT; i++)); do
-        "$@"
+        "$@" > /dev/null
     done
     END="$(date '+%s%N')"
     TIME=$(( END - START ))
-}
-
-run() {
-    "$1" < "$2" > /dev/null
 }
 
 benchmark() {
@@ -60,36 +73,48 @@ benchmark() {
 
     echo "Generating $GRAMMAR parser in $REF ($GEN_REPEATS times)..."
     measure "$GEN_REPEATS" "$PACKCC" -o "$NAME" "$GRAMMAR_FILE"
-    GEN["$KEY"]=$TIME
-    echo "  Repeated $GEN_REPEATS times in $(format $TIME)"
+    GEN_TIME["$KEY"]=$TIME
+    GEN_MEM["$KEY"]=$MEM
+    echo "  Repeated $GEN_REPEATS times in $(format $TIME), peak memory $(format_mem $MEM)"
 
     echo "Building $GRAMMAR parser in $REF ($BUILD_REPEATS times)..."
     measure "$BUILD_REPEATS" $CC -I. "$NAME".c -o "$NAME"
-    BUILD["$KEY"]=$TIME
-    echo "  Built $BUILD_REPEATS times in $(format $TIME)"
+    BUILD_TIME["$KEY"]=$TIME
+    BUILD_MEM["$KEY"]=$MEM
+    echo "  Built $BUILD_REPEATS times in $(format $TIME), peak memory $(format_mem $MEM)"
 
     echo "Running $GRAMMAR parser in $REF ($RUN_REPEATS times)..."
-    measure "$RUN_REPEATS" run "./$NAME" "$INPUT"
-    RUN["$KEY"]=$TIME
-    echo "  Repeated $RUN_REPEATS times in $(format $TIME)"
+    measure "$RUN_REPEATS" "./$NAME" "$INPUT"
+    RUN_TIME["$KEY"]=$TIME
+    RUN_MEM["$KEY"]=$MEM
+    echo "  Repeated $RUN_REPEATS times in $(format $TIME), peak memory $(format_mem $MEM)"
 }
 
 print_table() {
-    declare -n RESULTS="$1"
+    declare -n RESULTS_TIME="${1}_TIME"
+    declare -n RESULTS_MEM="${1}_MEM"
     printf "%-12s" ""
     for REF in "${REFS[@]}"; do
-        printf "%-16s" "$REF"
+        printf "%-32s" "$REF"
     done
     printf "\n"
+    MEMORY=0
+    RELATIVE_MEM="???"
+    COLOR_MEM=0
     for GRAMMAR in "${GRAMMARS[@]}"; do
         printf "%-12s" "$GRAMMAR"
         for REF in "${REFS[@]}"; do
             KEY="${GRAMMAR}_${REF//\//_}"
             BASE="${GRAMMAR}_${REFS[0]//\//_}"
-            TIME="$((${RESULTS["$KEY"]} / RUN_REPEATS))"
-            RELATIVE="$((100 * RESULTS["$KEY"] / RESULTS["$BASE"]))"
-            COLOR=$((RELATIVE == 100 ? 0 : ( RELATIVE > 100 ? 31 : 32)))
-            printf "\033[0;${COLOR}m%-16s\033[0m" "$(format $TIME) ($RELATIVE%)"
+            TIME="$((${RESULTS_TIME["$KEY"]} / RUN_REPEATS))"
+            RELATIVE_TIME="$((100 * RESULTS_TIME["$KEY"] / RESULTS_TIME["$BASE"]))"
+            COLOR=$((RELATIVE_TIME == 100 ? 0 : ( RELATIVE_TIME > 100 ? 31 : 32)))
+            if [ "$TIME_CMD" ]; then
+                MEMORY="${RESULTS_MEM["$KEY"]}"
+                RELATIVE_MEM="$((100 * RESULTS_MEM["$KEY"] / RESULTS_MEM["$BASE"]))"
+                COLOR_MEM=$((RELATIVE_MEM == 100 ? 0 : ( RELATIVE_MEM > 100 ? 31 : 32)))
+            fi
+            printf "\033[0;${COLOR}m%-16s\033[0;${COLOR_MEM}m%-16s\033[0m" "$(format $TIME) ($RELATIVE_TIME%)" "$(format_mem $MEMORY) ($RELATIVE_MEM%)"
         done
         printf "\n"
     done
@@ -97,17 +122,18 @@ print_table() {
 
 print_results() {
     echo
-    echo "Generation times:"
-    echo "================="
+    echo "Generation performance:"
+    echo "======================="
     print_table GEN
     echo
-    echo "Build times:"
-    echo "============"
+    echo "Build performance:"
+    echo "=================="
     print_table BUILD
     echo
-    echo "Run times:"
-    echo "=========="
+    echo "Run performance:"
+    echo "================"
     print_table RUN
+    echo
 }
 
 main() {
@@ -116,19 +142,26 @@ main() {
     BENCHDIR="$(cd "$(dirname "$0")" && pwd)"
     ROOTDIR="$BENCHDIR/.."
     declare -a GRAMMARS=()
-    declare -A BUILD=()
-    declare -A GEN=()
-    declare -A RUN=()
+    declare -A BUILD_TIME GEN_TIME RUN_TIME BUILD_MEM GEN_MEM RUN_MEM
 
-    declare -i GEN_REPEATS="${GEN_REPEATS:-10}"
-    declare -i BUILD_REPEATS="${BUILD_REPEATS:-5}"
-    declare -i RUN_REPEATS="${RUN_REPEATS:-20}"
+    declare -i GEN_REPEATS="${GEN_REPEATS:-1}"
+    declare -i BUILD_REPEATS="${BUILD_REPEATS:-1}"
+    declare -i RUN_REPEATS="${RUN_REPEATS:-1}"
     CC="${CC:-cc -O2}"
     REFS=("$@")
 
     if [[ $# -eq 0 || "$1" =~ -h|--help|--usage ]]; then
         sed -n '3,/^$/s/^#//p' "$0"
         exit 0
+    fi
+
+    if which busybox &> /dev/null; then
+        TIME_CMD=(busybox time)
+    elif which time &> /dev/null; then
+        TIME_CMD=("$(which time)")
+    else
+        echo "NOTE: No time command found, please install GNU time or busybox to measure memory consumption."
+        TIME_CMD=""
     fi
 
     START_REF="$(git name-rev --name-only HEAD)"

--- a/benchmark/grammars/calc.peg
+++ b/benchmark/grammars/calc.peg
@@ -29,7 +29,10 @@ _      <- [ \t]*
 EOL    <- '\n' / '\r\n' / '\r' / ';'
 
 %%
-int main() {
+int main(int argc, char **argv) {
+    if (argc > 1) {
+        freopen(argv[1], "r", stdin);
+    }
     calc_context_t *ctx = calc_create(NULL);
     while (calc_parse(ctx, NULL));
     calc_destroy(ctx);

--- a/benchmark/grammars/json.peg
+++ b/benchmark/grammars/json.peg
@@ -12,7 +12,10 @@ null <- 'null'
 _  <- [ \n\r\t]*
 
 %%
-int main() {
+int main(int argc, char **argv) {
+    if (argc > 1) {
+        freopen(argv[1], "r", stdin);
+    }
     json_context_t *ctx = json_create(NULL);
     while (json_parse(ctx, NULL));
     json_destroy(ctx);

--- a/benchmark/grammars/kotlin.peg
+++ b/benchmark/grammars/kotlin.peg
@@ -441,6 +441,9 @@ EOF <- !.
 %%
 
 int main(int argc, char **argv) {
+    if (argc > 1) {
+        freopen(argv[1], "r", stdin);
+    }
     int ret;
     pcc_context_t *ctx = pcc_create(NULL);
     while (pcc_parse(ctx, &ret));


### PR DESCRIPTION
I wanted to see the memory consumption impact of changes suggested in #63 and I realized that it is possible to improve the benchmark script to also show memory stats. The script requires GNU time or busybox to be installed in order to measure the memory usage, but it works even if it is not installed (just not showing the memory related values).

With these changes, the output now looks like this:
```
Generation performance:
=======================
            upstream/master                 masatake/recycle-list           
calc        1299 us (100%)  6480 kB (100%)  832 us (64%)    6512 kB (100%)  
json        1105 us (100%)  6528 kB (100%)  841 us (76%)    6960 kB (106%)  
kotlin      3395 us (100%)  8800 kB (100%)  3295 us (97%)   9120 kB (103%)  

Build performance:
==================
            upstream/master                 masatake/recycle-list           
calc        107 ms (100%)   128 MB (100%)   113 ms (105%)   129 MB (100%)   
json        102 ms (100%)   125 MB (100%)   103 ms (101%)   124 MB (99%)    
kotlin      1165 ms (100%)  434 MB (100%)   1161 ms (99%)   432 MB (99%)    

Run performance:
================
            upstream/master                 masatake/recycle-list           
calc        168 ms (100%)   264 MB (100%)   150 ms (89%)    241 MB (91%)    
json        47 ms (100%)    113 MB (100%)   37 ms (78%)     100 MB (88%)    
kotlin      398 ms (100%)   495 MB (100%)   308 ms (77%)    426 MB (86%)    
```

