### PR TITLE
Document how to stop parsing on error instead of exiting.

### DIFF
--- a/README.md
+++ b/README.md
@@ -485,6 +485,14 @@ static void pcc_error(void) {
 }
 ```
 
+To stop parsing without aborting the process, this definition will return `0` from `pcc_parse(pcc_context_t *ctx, int *ret)`:
+
+```C
+#define PCC_ERROR(auxil) return 0
+```
+
+This is useful when the grammar does not handle all inputs: if the input does not match any rule, the input buffer never gets empty and `pcc_parse()` returns nonzero again and again. The `return 0` will stop that.
+
 **`PCC_MALLOC(`**_auxil_**`,`**_size_**`)`**
 
 The function macro to allocate a memory block.


### PR DESCRIPTION
I just started using `packcc` yesterday. I modified the `calc` example to read from a line buffer that did not contain EOL, and made a custom `PCC_ERROR` that printed an error message but did not exit, because I wanted to print an error message and then read the next line.
It took me a while to realize why my parse loop never ended.

I thought this might be related to #43 “Simple grammar goes into an infinite loop instead of erroring”, but in that case the parser is working correctly, matching ε again and again.

Of course the real fix is to modify the grammar to make it handle all inputs and report errors from there, but it is useful to have this way of stopping when an error occurs. What I do now is to store a special error message in `auxil` inside `PCC_ERROR` and then return `0`; that way control goes back to the main program which prints that special error message saying that the grammar does not match all inputs.