### PR TITLE
Avoid resizing empty capture and value tables

### DIFF
--- a/src/packcc.c
+++ b/src/packcc.c
@@ -4716,17 +4716,19 @@ static bool_t generate(context_t *ctx) {
                     "    ctx->level++;\n",
                     ctx->rules.buf[i]->data.rule.name
                 );
-                stream__printf(
-                    &sstream,
-                    "    pcc_value_table__resize(ctx->auxil, &chunk->values, " FMT_LU ");\n",
-                    (ulong_t)ctx->rules.buf[i]->data.rule.vars.len
-                );
-                stream__printf(
-                    &sstream,
-                    "    pcc_capture_table__resize(ctx->auxil, &chunk->capts, " FMT_LU ");\n",
-                    (ulong_t)ctx->rules.buf[i]->data.rule.capts.len
-                );
+                if (ctx->rules.buf[i]->data.rule.capts.len > 0) {
+                    stream__printf(
+                        &sstream,
+                        "    pcc_capture_table__resize(ctx->auxil, &chunk->capts, " FMT_LU ");\n",
+                        (ulong_t)ctx->rules.buf[i]->data.rule.capts.len
+                    );
+                }
                 if (ctx->rules.buf[i]->data.rule.vars.len > 0) {
+                    stream__printf(
+                        &sstream,
+                        "    pcc_value_table__resize(ctx->auxil, &chunk->values, " FMT_LU ");\n",
+                        (ulong_t)ctx->rules.buf[i]->data.rule.vars.len
+                    );
                     stream__puts(
                         &sstream,
                         "    pcc_value_table__clear(ctx->auxil, &chunk->values);\n"


### PR DESCRIPTION
I have noticed that PackCC generates calls to `pcc_value_table__resize` and `pcc_value_table__resize` even when there are no captures or values respectively. 

I'd expect this to have no measurable impact, as the first instruction in the function is actually checking if the resize is needed. But benchmarking shows, that it is actually measurable and that avoiding the function calls results in consistent speed improvement of couple percent:

```
$ RUN_REPEATS=200 benchmark/benchmark.sh origin/master optimize-table-resizing
...
Run performance:
================
            origin/master                   optimize-table-resizing         
calc        132 ms (100%)   258 MB (100%)   132 ms (99%)    250 MB (96%)    
json        33 ms (100%)    101 MB (100%)   33 ms (98%)     101 MB (99%)    
kotlin      245 ms (100%)   410 MB (100%)   234 ms (95%)    409 MB (99%)    
```
I have tested it with gcc 13 and clang 16, both with -O2.